### PR TITLE
Simplify utilization overlay colormap to 3-level threshold

### DIFF
--- a/backend/app/routers/utilization.py
+++ b/backend/app/routers/utilization.py
@@ -31,24 +31,16 @@ class AggregationType(str, Enum):
 
 
 # Color scale for utilization heatmap (0-100%)
-# Green (low) -> Yellow (medium) -> Red (high)
+# <25% = Green, 25-50% = Orange, >50% = Red
 def get_color_for_utilization(value: float) -> str:
     """Get heatmap color for utilization value (0-100%)."""
     if value < 0:
         return "transparent"
-    if value <= 10:
-        return "rgba(0, 128, 0, 0.5)"  # Green
-    if value <= 25:
-        return "rgba(50, 205, 50, 0.5)"  # Lime Green
-    if value <= 40:
-        return "rgba(154, 205, 50, 0.5)"  # Yellow-Green
-    if value <= 55:
-        return "rgba(255, 255, 0, 0.5)"  # Yellow
-    if value <= 70:
-        return "rgba(255, 165, 0, 0.6)"  # Orange
-    if value <= 85:
-        return "rgba(255, 69, 0, 0.6)"  # Red-Orange
-    return "rgba(255, 0, 0, 0.7)"  # Red
+    if value < 25:
+        return "rgba(0, 128, 0, 0.5)"  # Green (low utilization)
+    if value <= 50:
+        return "rgba(255, 165, 0, 0.6)"  # Orange (medium utilization)
+    return "rgba(255, 0, 0, 0.7)"  # Red (high utilization)
 
 
 class UtilizationConfigRequest(BaseModel):

--- a/frontend/src/components/Map/UtilizationImageOverlay.tsx
+++ b/frontend/src/components/Map/UtilizationImageOverlay.tsx
@@ -18,15 +18,12 @@ interface UtilizationImageOverlayProps {
 }
 
 // Get color for utilization value (0-100%), returns [r, g, b, a]
+// <25% = Green, 25-50% = Orange, >50% = Red
 function getUtilizationRGBA(value: number): [number, number, number, number] {
   if (value < 0) return [0, 0, 0, 0]           // Transparent
-  if (value <= 10) return [0, 128, 0, 150]     // Green
-  if (value <= 25) return [50, 205, 50, 150]   // Lime Green
-  if (value <= 40) return [154, 205, 50, 150]  // Yellow-Green
-  if (value <= 55) return [255, 255, 0, 150]   // Yellow
-  if (value <= 70) return [255, 165, 0, 170]   // Orange
-  if (value <= 85) return [255, 69, 0, 170]    // Red-Orange
-  return [255, 0, 0, 190]                       // Red
+  if (value < 25) return [0, 128, 0, 150]      // Green (low utilization)
+  if (value <= 50) return [255, 165, 0, 170]   // Orange (medium utilization)
+  return [255, 0, 0, 190]                       // Red (high utilization)
 }
 
 export default function UtilizationImageOverlay({ cells, blur = 8 }: UtilizationImageOverlayProps) {


### PR DESCRIPTION
## Summary
- Changed the utilization overlay colormap from 7 gradual levels to 3 distinct threshold-based levels
- Green: <25% utilization (healthy network)
- Orange: 25-50% utilization (moderate congestion)
- Red: >50% utilization (high congestion)

## Changes
- `frontend/src/components/Map/UtilizationImageOverlay.tsx` - Updated `getUtilizationRGBA()` function
- `backend/app/routers/utilization.py` - Updated `get_color_for_utilization()` function

## Test plan
- [ ] Generate utilization overlay on map
- [ ] Verify colors match thresholds (green <25%, orange 25-50%, red >50%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)