### PR TITLE
feat: Add insufficient solar warning and improved charge rate calculation

### DIFF
--- a/frontend/src/components/Analysis/Analysis.test.tsx
+++ b/frontend/src/components/Analysis/Analysis.test.tsx
@@ -66,6 +66,7 @@ const mockSolarAnalysis = {
       ],
       avg_charge_rate_per_hour: 3.85,
       avg_discharge_rate_per_hour: 0.54,
+      insufficient_solar: false,
     },
     {
       node_num: 87654321,
@@ -78,6 +79,7 @@ const mockSolarAnalysis = {
       chart_data: [],
       avg_charge_rate_per_hour: 0.08,
       avg_discharge_rate_per_hour: 0.02,
+      insufficient_solar: true,
     },
   ],
   solar_production: [
@@ -465,5 +467,25 @@ describe('SolarMonitoring', () => {
     fireEvent.change(input, { target: { value: '14' } })
 
     expect(input).toHaveValue(14)
+  })
+
+  it('displays "Low Solar" warning for nodes with insufficient solar output', async () => {
+    render(<AnalysisPage />)
+
+    // Open solar monitoring
+    const card = screen.getByText('Solar Monitoring Analysis').closest('button')
+    fireEvent.click(card!)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Identify Solar Nodes/i })).toBeInTheDocument()
+    })
+
+    // Click analyze button
+    fireEvent.click(screen.getByRole('button', { name: /Identify Solar Nodes/i }))
+
+    // Should show "Low Solar" warning for the second node (insufficient_solar: true)
+    await waitFor(() => {
+      expect(screen.getByText('Low Solar')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/Analysis/SolarMonitoring.tsx
+++ b/frontend/src/components/Analysis/SolarMonitoring.tsx
@@ -299,7 +299,25 @@ function SolarNodeCard({ node, solarProduction }: { node: SolarNode; solarProduc
         }}
       >
         <div>
-          <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>{node.node_name}</div>
+          <div style={{ fontWeight: 600, marginBottom: '0.25rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            {node.node_name}
+            {node.insufficient_solar && (
+              <span
+                title="Insufficient solar output: charge rate does not sufficiently exceed discharge rate"
+                style={{
+                  background: 'var(--color-warning, #f59e0b)',
+                  color: '#000',
+                  fontSize: '0.65rem',
+                  fontWeight: 700,
+                  padding: '0.15rem 0.4rem',
+                  borderRadius: '4px',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Low Solar
+              </span>
+            )}
+          </div>
           <div style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)' }}>
             !{node.node_num.toString(16).padStart(8, '0')}
           </div>

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -301,6 +301,7 @@ describe('API Service', () => {
             chart_data: [],
             avg_charge_rate_per_hour: 3.85,
             avg_discharge_rate_per_hour: 0.54,
+            insufficient_solar: false,
           },
         ],
         solar_production: [],

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -324,6 +324,7 @@ export interface SolarNode {
   chart_data: SolarChartPoint[]
   avg_charge_rate_per_hour: number | null
   avg_discharge_rate_per_hour: number | null
+  insufficient_solar: boolean | null
 }
 
 export interface SolarProductionPoint {


### PR DESCRIPTION
## Summary
- Add `insufficient_solar` flag to solar nodes API when charge output doesn't sufficiently exceed discharge (within 10% threshold)
- Display "Low Solar" warning badge in UI for flagged nodes
- Improve charge rate calculation: use time battery hits 100% instead of peak time if battery reaches full charge before sunset

## Test plan
- [x] Run frontend test suite (63 tests pass)
- [x] Verify "Low Solar" badge appears for nodes with insufficient solar
- [x] Verify charge rate calculation uses 100% time when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)