### PR TITLE
chore: Bump version to 0.2.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bumps frontend version from 0.1.0 to 0.2.0

## Test plan
- [x] All tests pass locally (70 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)