### PR TITLE
feat: Add solar chart with nodes-at-risk subplots to notifications

### DIFF
--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,8 +1,16 @@
 """Notification service using Apprise."""
 
+import io
 import logging
+import tempfile
+from datetime import datetime
 
 import apprise
+import matplotlib
+import matplotlib.pyplot as plt
+
+# Use non-interactive backend for server-side rendering
+matplotlib.use("Agg")
 
 logger = logging.getLogger(__name__)
 
@@ -10,13 +18,16 @@ logger = logging.getLogger(__name__)
 class NotificationService:
     """Send notifications via Apprise."""
 
-    async def send(self, urls: list[str], title: str, body: str) -> dict:
+    async def send(
+        self, urls: list[str], title: str, body: str, image_path: str | None = None
+    ) -> dict:
         """Send notification to multiple Apprise URLs.
 
         Args:
             urls: List of Apprise notification URLs
             title: Notification title
             body: Notification body text
+            image_path: Optional path to image file to attach
 
         Returns:
             Dict with success status and count of URLs
@@ -30,7 +41,14 @@ class NotificationService:
             apobj.add(url)
 
         try:
-            success = apobj.notify(title=title, body=body)
+            # Prepare attachment if image provided
+            attach = None
+            if image_path:
+                attach = apprise.AppriseAttachment()
+                attach.add(image_path)
+                logger.info(f"Attaching image: {image_path}")
+
+            success = apobj.notify(title=title, body=body, attach=attach)
             logger.info(f"Notification sent to {len(urls)} URLs, success={success}")
             return {"success": success, "urls_count": len(urls)}
         except Exception as e:
@@ -122,6 +140,329 @@ class NotificationService:
                     lines.append(f"  _...and {len(nodes_at_risk) - 5} more_")
 
         return title, "\n".join(lines)
+
+    def generate_solar_chart(
+        self,
+        analysis: dict,
+        forecast: dict,
+        solar_production: list[dict],
+    ) -> str | None:
+        """Generate a solar production chart image with nodes at risk.
+
+        Args:
+            analysis: Solar nodes analysis data
+            forecast: Solar forecast analysis data
+            solar_production: Hourly solar production data points
+
+        Returns:
+            Path to generated image file, or None if generation fails
+        """
+        try:
+            # Get today's date for determining actual vs forecast
+            today = datetime.now().strftime("%Y-%m-%d")
+
+            # Aggregate hourly solar production into daily totals
+            daily_totals: dict[str, float] = {}
+            for point in solar_production:
+                # Convert timestamp (milliseconds) to date string
+                ts = point.get("timestamp", 0)
+                if ts:
+                    date = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d")
+                    daily_totals[date] = daily_totals.get(date, 0) + point.get("wattHours", 0)
+
+            # Get forecast data by date
+            forecast_by_date = {
+                d["date"]: d["forecast_wh"] for d in forecast.get("forecast_days", [])
+            }
+
+            # Collect all dates
+            all_dates = sorted(set(daily_totals.keys()) | set(forecast_by_date.keys()))
+
+            # Prepare chart data
+            dates = []
+            actual_values = []
+            forecast_values = []
+
+            for date in all_dates:
+                dates.append(date)
+                is_future = date > today
+
+                # Actual: only for today and past
+                if not is_future and date in daily_totals:
+                    actual_values.append(daily_totals[date])
+                else:
+                    actual_values.append(0)
+
+                # Forecast: only for today and future
+                if (date >= today) and date in forecast_by_date:
+                    forecast_values.append(forecast_by_date[date])
+                else:
+                    forecast_values.append(0)
+
+            if not dates:
+                logger.warning("No data available for solar chart")
+                return None
+
+            # Get average for reference line
+            avg_historical = forecast.get("avg_historical_daily_wh", 0)
+            warning_threshold = avg_historical * 0.75
+
+            # Get nodes at risk for subplots
+            nodes_at_risk = forecast.get("nodes_at_risk", [])
+            num_risk_nodes = len(nodes_at_risk)
+
+            # Calculate figure layout
+            # Main chart on top, then 2-column grid for risk nodes below
+            num_risk_rows = (num_risk_nodes + 1) // 2  # Ceiling division for 2 columns
+            total_rows = 1 + num_risk_rows if num_risk_nodes > 0 else 1
+
+            # Create figure with subplots
+            if num_risk_nodes > 0:
+                # Use GridSpec for flexible layout
+                fig = plt.figure(figsize=(10, 4 + num_risk_rows * 2.5), layout="constrained")
+                gs = fig.add_gridspec(
+                    total_rows, 2,
+                    height_ratios=[2] + [1] * num_risk_rows if num_risk_rows > 0 else [1],
+                    hspace=0.1,
+                    wspace=0.1
+                )
+                ax_main = fig.add_subplot(gs[0, :])  # Main chart spans both columns
+            else:
+                fig, ax_main = plt.subplots(figsize=(10, 5), layout="constrained")
+
+            # Set dark theme for figure
+            fig.patch.set_facecolor("#1e1e2e")
+
+            # === Main Solar Production Chart ===
+            ax_main.set_facecolor("#1e1e2e")
+
+            x = range(len(dates))
+            bar_width = 0.35
+
+            # Plot bars
+            ax_main.bar(
+                [i - bar_width / 2 for i in x],
+                actual_values,
+                bar_width,
+                label="Actual",
+                color="#89b4fa",
+            )
+            ax_main.bar(
+                [i + bar_width / 2 for i in x],
+                forecast_values,
+                bar_width,
+                label="Forecast",
+                color="#f9e2af",
+            )
+
+            # Add reference lines
+            if avg_historical > 0:
+                ax_main.axhline(
+                    y=avg_historical,
+                    color="#a6adc8",
+                    linestyle="--",
+                    linewidth=2,
+                    label=f"Average ({avg_historical:.0f} Wh)",
+                )
+                ax_main.axhline(
+                    y=warning_threshold,
+                    color="#ef4444",
+                    linestyle="--",
+                    linewidth=2,
+                    label=f"75% Warning ({warning_threshold:.0f} Wh)",
+                )
+
+            # Format x-axis labels (show month/day)
+            date_labels = [f"{d[5:7]}/{d[8:10]}" for d in dates]
+            ax_main.set_xticks(list(x))
+            ax_main.set_xticklabels(date_labels, color="#cdd6f4")
+
+            # Style main chart
+            ax_main.set_ylabel("Watt Hours", color="#cdd6f4")
+            ax_main.set_title(
+                "Daily Solar Production", color="#cdd6f4", fontsize=14, fontweight="bold"
+            )
+            ax_main.tick_params(colors="#cdd6f4")
+            for spine in ax_main.spines.values():
+                spine.set_color("#45475a")
+
+            # Legend
+            ax_main.legend(
+                loc="upper left", facecolor="#313244", edgecolor="#45475a", labelcolor="#cdd6f4"
+            )
+
+            # Grid
+            ax_main.yaxis.grid(True, color="#45475a", linestyle="--", alpha=0.5)
+            ax_main.set_axisbelow(True)
+
+            # === Nodes at Risk Subplots ===
+            # Build lookup for solar_nodes by node_num for historical chart_data
+            solar_nodes_by_num = {
+                n.get("node_num"): n for n in analysis.get("solar_nodes", [])
+            }
+
+            # Build hourly solar production lookup (timestamp in ms -> wattHours)
+            solar_by_hour: dict[int, float] = {}
+            for sp in solar_production:
+                ts = sp.get("timestamp", 0)
+                if ts:
+                    hour_ts = (ts // 3600000) * 3600000  # Round to hour
+                    solar_by_hour[hour_ts] = sp.get("wattHours", 0)
+
+            # Find max solar wattHours for scaling the background
+            max_solar_wh = max(solar_by_hour.values()) if solar_by_hour else 1
+
+            for idx, node in enumerate(nodes_at_risk):
+                row = 1 + idx // 2  # Start from row 1 (row 0 is main chart)
+                col = idx % 2
+
+                ax = fig.add_subplot(gs[row, col])
+                ax.set_facecolor("#1e1e2e")
+
+                node_num = node.get("node_num")
+                min_battery = node.get("min_simulated_battery", 0)
+
+                # Get historical chart_data from solar_nodes analysis
+                solar_node = solar_nodes_by_num.get(node_num, {})
+                chart_data = solar_node.get("chart_data", [])
+
+                # Get forecast simulation data
+                simulation = node.get("simulation", [])
+
+                # Collect all data points: historical + forecast
+                hist_times = []
+                hist_batteries = []
+                forecast_times = []
+                forecast_batteries = []
+
+                # Parse historical data (convert to naive datetime for consistency)
+                for point in chart_data:
+                    ts = point.get("timestamp", 0)
+                    value = point.get("value")
+                    if ts and value is not None:
+                        hist_times.append(datetime.fromtimestamp(ts / 1000))
+                        hist_batteries.append(value)
+
+                # Parse forecast simulation (convert to naive datetime for consistency)
+                for sim_point in simulation:
+                    ts_str = sim_point.get("timestamp", "")
+                    if ts_str:
+                        try:
+                            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                            # Convert to naive datetime by removing timezone
+                            ts = ts.replace(tzinfo=None)
+                            forecast_times.append(ts)
+                            forecast_batteries.append(sim_point.get("simulated_battery", 0))
+                        except ValueError:
+                            continue
+
+                # Need at least some data to plot
+                if not hist_times and not forecast_times:
+                    continue
+
+                # Determine time range for solar background
+                all_times = hist_times + forecast_times
+                if not all_times:
+                    continue
+
+                min_time = min(all_times)
+                max_time = max(all_times)
+
+                # Create secondary y-axis for solar production
+                ax2 = ax.twinx()
+
+                # Plot solar production as semi-transparent background area
+                solar_times = []
+                solar_values = []
+                for hour_ts, wh in sorted(solar_by_hour.items()):
+                    dt = datetime.fromtimestamp(hour_ts / 1000)
+                    # Only include solar data within the chart time range (with some padding)
+                    if min_time <= dt <= max_time:
+                        solar_times.append(dt)
+                        solar_values.append(wh)
+
+                if solar_times:
+                    ax2.fill_between(
+                        solar_times, 0, solar_values,
+                        color="#f9e2af", alpha=0.15, label="Solar"
+                    )
+                    ax2.set_ylim(0, max_solar_wh * 1.1)
+                    ax2.tick_params(colors="#f9e2af", labelsize=6)
+                    ax2.set_ylabel("Wh", color="#f9e2af", fontsize=7)
+                    for spine in ax2.spines.values():
+                        spine.set_color("#45475a")
+
+                # Color based on severity
+                if min_battery <= 10:
+                    line_color = "#f38ba8"  # Red
+                elif min_battery <= 30:
+                    line_color = "#f9e2af"  # Yellow
+                else:
+                    line_color = "#a6e3a1"  # Green
+
+                # Plot historical battery data (solid line)
+                if hist_times:
+                    ax.plot(
+                        hist_times, hist_batteries,
+                        color="#89b4fa", linewidth=1.5, label="Actual"
+                    )
+
+                # Plot forecast battery data (dashed line, different color)
+                if forecast_times:
+                    # Add bridge point to connect historical to forecast
+                    if hist_times and hist_batteries:
+                        bridge_times = [hist_times[-1]] + forecast_times
+                        bridge_batteries = [hist_batteries[-1]] + forecast_batteries
+                    else:
+                        bridge_times = forecast_times
+                        bridge_batteries = forecast_batteries
+
+                    ax.plot(
+                        bridge_times, bridge_batteries,
+                        color=line_color, linewidth=2, linestyle="--",
+                        marker="o", markersize=3, label="Forecast"
+                    )
+
+                # Add warning threshold lines
+                ax.axhline(y=50, color="#f9e2af", linestyle=":", linewidth=1, alpha=0.5)
+                ax.axhline(y=25, color="#f38ba8", linestyle=":", linewidth=1, alpha=0.5)
+
+                # Style subplot
+                node_name = node.get("node_name", "Unknown")
+                # Truncate long names
+                if len(node_name) > 20:
+                    node_name = node_name[:17] + "..."
+                ax.set_title(
+                    f"{node_name} (min: {min_battery:.0f}%)",
+                    color="#cdd6f4", fontsize=10, fontweight="bold"
+                )
+                ax.set_ylabel("Battery %", color="#cdd6f4", fontsize=8)
+                ax.set_ylim(0, 110)
+                ax.tick_params(colors="#cdd6f4", labelsize=7)
+                for spine in ax.spines.values():
+                    spine.set_color("#45475a")
+
+                # Format x-axis with readable time labels
+                ax.xaxis.set_major_formatter(plt.matplotlib.dates.DateFormatter("%m/%d"))
+                plt.setp(ax.xaxis.get_majorticklabels(), rotation=30, ha="right", fontsize=7)
+
+                # Grid
+                ax.yaxis.grid(True, color="#45475a", linestyle="--", alpha=0.5)
+                ax.set_axisbelow(True)
+
+            # Save to temp file
+            temp_file = tempfile.NamedTemporaryFile(
+                suffix=".png", delete=False, prefix="solar_chart_"
+            )
+            plt.savefig(temp_file.name, dpi=150, facecolor=fig.get_facecolor())
+            plt.close(fig)
+
+            logger.info(f"Generated solar chart: {temp_file.name}")
+            return temp_file.name
+
+        except Exception as e:
+            logger.error(f"Failed to generate solar chart: {e}")
+            return None
 
 
 # Global notification service instance

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "rasterio>=1.3",
     "fiona>=1.9",
     "apprise>=1.9",
+    "matplotlib>=3.8",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Generate matplotlib chart image that is attached to scheduled solar analysis notifications
- Main chart shows daily solar production (actual vs forecast) with average and 75% warning threshold reference lines
- Add 2-column grid of node-at-risk subplots below the main chart
- Each subplot shows historical battery data + forecast simulation with solar production as semi-transparent background
- Color-code forecast lines by severity (red for ≤10%, yellow for ≤30%, green otherwise)
- Add threshold reference lines at 50% and 25% battery levels
- Y-axis scaled to 110% to accommodate nodes that report 101% when fully charged
- Dark Catppuccin theme matching frontend styling

## Test plan
- [ ] Trigger a test notification via the UI
- [ ] Verify the attached chart image includes the main solar production chart
- [ ] Verify nodes-at-risk subplots appear in 2-column layout
- [ ] Confirm historical battery data + forecast simulation are both visible
- [ ] Confirm solar production background is visible as semi-transparent yellow
- [ ] Verify y-axis extends to 110% and threshold lines are at 50%/25%

🤖 Generated with [Claude Code](https://claude.com/claude-code)