### PR TITLE
feat: Default Active Only checkbox to checked with localStorage persistence

### DIFF
--- a/frontend/src/contexts/DataContext.test.tsx
+++ b/frontend/src/contexts/DataContext.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { DataProvider, useDataContext } from './DataContext'
 import type { ReactNode } from 'react'
@@ -8,6 +8,9 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 )
 
 describe('DataContext', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
   describe('useDataContext', () => {
     it('should throw error when used outside DataProvider', () => {
       expect(() => {
@@ -20,7 +23,7 @@ describe('DataContext', () => {
 
       expect(result.current.selectedNode).toBeNull()
       expect(result.current.enabledSourceIds.size).toBe(0)
-      expect(result.current.showActiveOnly).toBe(false)
+      expect(result.current.showActiveOnly).toBe(true) // Default is true
       expect(result.current.activeHours).toBe(24)
       expect(result.current.onlineHours).toBe(1)
     })
@@ -174,14 +177,19 @@ describe('DataContext', () => {
   })
 
   describe('showActiveOnly', () => {
-    it('should update showActiveOnly when setShowActiveOnly is called', () => {
+    it('should default to true when no localStorage value', () => {
       const { result } = renderHook(() => useDataContext(), { wrapper })
+      expect(result.current.showActiveOnly).toBe(true)
+    })
 
+    it('should read initial value from localStorage', () => {
+      localStorage.setItem('showActiveOnly', 'false')
+      const { result } = renderHook(() => useDataContext(), { wrapper })
       expect(result.current.showActiveOnly).toBe(false)
+    })
 
-      act(() => {
-        result.current.setShowActiveOnly(true)
-      })
+    it('should update showActiveOnly and persist to localStorage', () => {
+      const { result } = renderHook(() => useDataContext(), { wrapper })
 
       expect(result.current.showActiveOnly).toBe(true)
 
@@ -190,6 +198,14 @@ describe('DataContext', () => {
       })
 
       expect(result.current.showActiveOnly).toBe(false)
+      expect(localStorage.getItem('showActiveOnly')).toBe('false')
+
+      act(() => {
+        result.current.setShowActiveOnly(true)
+      })
+
+      expect(result.current.showActiveOnly).toBe(true)
+      expect(localStorage.getItem('showActiveOnly')).toBe('true')
     })
   })
 

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -20,7 +20,10 @@ const DataContext = createContext<DataContextValue | null>(null)
 export function DataProvider({ children }: { children: ReactNode }) {
   const [selectedNode, setSelectedNode] = useState<Node | null>(null)
   const [enabledSourceIds, setEnabledSourceIds] = useState<Set<string>>(new Set())
-  const [showActiveOnly, setShowActiveOnly] = useState(false)
+  const [showActiveOnly, setShowActiveOnlyState] = useState(() => {
+    const stored = localStorage.getItem('showActiveOnly')
+    return stored !== null ? stored === 'true' : true // Default to true
+  })
   const [activeHours, setActiveHours] = useState(24)
   const [onlineHours, setOnlineHours] = useState(1)
 
@@ -38,6 +41,11 @@ export function DataProvider({ children }: { children: ReactNode }) {
 
   const enableAllSources = (sourceIds: string[]) => {
     setEnabledSourceIds(new Set(sourceIds))
+  }
+
+  const setShowActiveOnly = (active: boolean) => {
+    localStorage.setItem('showActiveOnly', String(active))
+    setShowActiveOnlyState(active)
   }
 
   const value: DataContextValue = {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -22,12 +22,19 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 })
 
-// Mock localStorage
+// Mock localStorage with functional storage
+const localStorageStore: Record<string, string> = {}
 const localStorageMock = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
+  getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageStore[key] = value
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete localStorageStore[key]
+  }),
+  clear: vi.fn(() => {
+    Object.keys(localStorageStore).forEach((key) => delete localStorageStore[key])
+  }),
 }
 Object.defineProperty(window, 'localStorage', { value: localStorageMock })
 


### PR DESCRIPTION
## Summary

- Default the "Active Only" checkbox to checked (true) instead of unchecked
- Persist the checkbox state to localStorage so it remembers user preference across sessions

## Changes

- **DataContext.tsx**: Initialize `showActiveOnly` from localStorage, defaulting to `true`. Save to localStorage on change.
- **DataContext.test.tsx**: Updated tests for new default value and added localStorage persistence tests.

## Test plan

- [ ] Verify checkbox is checked by default on first visit
- [ ] Uncheck the box, refresh page - verify it stays unchecked
- [ ] Check the box, refresh page - verify it stays checked
- [ ] Clear localStorage, refresh - verify it defaults to checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)