### PR TITLE
feat: Add More Info button to map popup and persist history hours

### DIFF
--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react'
 import Header from './Header'
-import NavSidebar, { type Page } from './NavSidebar'
+import NavSidebar from './NavSidebar'
 import MapPage from '../Map/MapPage'
 import NodeDetailsPage from '../NodeDetails/NodeDetailsPage'
 import { GraphsPage } from '../Graphs'
 import { AnalysisPage } from '../Analysis'
 import { SettingsPage } from '../Settings'
+import { useDataContext } from '../../contexts/DataContext'
 
 export default function Layout() {
-  const [currentPage, setCurrentPage] = useState<Page>('map')
+  const { currentPage, navigateToPage } = useDataContext()
 
   const renderPage = () => {
     switch (currentPage) {
@@ -29,7 +29,7 @@ export default function Layout() {
 
   return (
     <div className="app-layout">
-      <NavSidebar currentPage={currentPage} onPageChange={setCurrentPage} />
+      <NavSidebar currentPage={currentPage} onPageChange={navigateToPage} />
       <main className="main-content">
         <Header />
         <div className="page-content">

--- a/frontend/src/components/Layout/NavSidebar.tsx
+++ b/frontend/src/components/Layout/NavSidebar.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useAuthContext } from '../../contexts/AuthContext'
-
-export type Page = 'map' | 'nodes' | 'graphs' | 'analysis' | 'settings'
+import { type Page } from '../../contexts/DataContext'
 
 interface NavSidebarProps {
   currentPage: Page

--- a/frontend/src/components/Map/MapContainer.tsx
+++ b/frontend/src/components/Map/MapContainer.tsx
@@ -147,7 +147,7 @@ function MapViewHandler() {
 }
 
 export default function MapContainer() {
-  const { enabledSourceIds, showActiveOnly, activeHours, onlineHours, selectedNode, setSelectedNode } = useDataContext()
+  const { enabledSourceIds, showActiveOnly, activeHours, onlineHours, selectedNode, setSelectedNode, navigateToPage } = useDataContext()
 
   // Load persisted settings from localStorage
   const [tilesetId, setTilesetId] = useState<TilesetId>(() =>
@@ -518,6 +518,26 @@ export default function MapContainer() {
                       <div>Last heard: {new Date(node.last_heard).toLocaleString()}</div>
                     )}
                   </div>
+                  <button
+                    onClick={() => {
+                      setSelectedNode(node)
+                      navigateToPage('nodes')
+                    }}
+                    style={{
+                      marginTop: '0.75rem',
+                      padding: '0.375rem 0.75rem',
+                      backgroundColor: 'var(--ctp-blue)',
+                      color: 'var(--ctp-base)',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '0.875rem',
+                      fontWeight: 500,
+                      width: '100%',
+                    }}
+                  >
+                    More Info
+                  </button>
                 </div>
               </Popup>
             </Marker>

--- a/frontend/src/components/NodeDetails/NodeDetailsPanel.tsx
+++ b/frontend/src/components/NodeDetails/NodeDetailsPanel.tsx
@@ -24,9 +24,19 @@ const TELEMETRY_METRICS = [
   { key: 'barometric_pressure', label: 'Pressure' },
 ]
 
+const STORAGE_KEY_HISTORY_HOURS = 'meshmanager_node_details_history_hours'
+
 export default function NodeDetailsPanel({ node }: NodeDetailsPanelProps) {
   const { onlineHours } = useDataContext()
-  const [historyHours, setHistoryHours] = useState(24)
+  const [historyHours, setHistoryHoursState] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY_HISTORY_HOURS)
+    return stored ? Number(stored) : 24
+  })
+
+  const setHistoryHours = (hours: number) => {
+    localStorage.setItem(STORAGE_KEY_HISTORY_HOURS, String(hours))
+    setHistoryHoursState(hours)
+  }
 
   // Fetch solar data for background on charts
   const { solarMap } = useSolarData(historyHours)

--- a/frontend/src/contexts/DataContext.test.tsx
+++ b/frontend/src/contexts/DataContext.test.tsx
@@ -26,6 +26,7 @@ describe('DataContext', () => {
       expect(result.current.showActiveOnly).toBe(true) // Default is true
       expect(result.current.activeHours).toBe(24)
       expect(result.current.onlineHours).toBe(1)
+      expect(result.current.currentPage).toBe('map')
     })
   })
 
@@ -246,6 +247,26 @@ describe('DataContext', () => {
       })
 
       expect(result.current.onlineHours).toBe(24)
+    })
+  })
+
+  describe('navigation', () => {
+    it('should update currentPage when navigateToPage is called', () => {
+      const { result } = renderHook(() => useDataContext(), { wrapper })
+
+      expect(result.current.currentPage).toBe('map')
+
+      act(() => {
+        result.current.navigateToPage('nodes')
+      })
+
+      expect(result.current.currentPage).toBe('nodes')
+
+      act(() => {
+        result.current.navigateToPage('settings')
+      })
+
+      expect(result.current.currentPage).toBe('settings')
     })
   })
 })

--- a/frontend/src/contexts/DataContext.tsx
+++ b/frontend/src/contexts/DataContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useState, type ReactNode } from 'react'
 import type { Node } from '../types/api'
 
+export type Page = 'map' | 'nodes' | 'graphs' | 'analysis' | 'settings'
+
 interface DataContextValue {
   selectedNode: Node | null
   setSelectedNode: (node: Node | null) => void
@@ -13,6 +15,8 @@ interface DataContextValue {
   setActiveHours: (hours: number) => void
   onlineHours: number
   setOnlineHours: (hours: number) => void
+  currentPage: Page
+  navigateToPage: (page: Page) => void
 }
 
 const DataContext = createContext<DataContextValue | null>(null)
@@ -26,6 +30,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
   })
   const [activeHours, setActiveHours] = useState(24)
   const [onlineHours, setOnlineHours] = useState(1)
+  const [currentPage, setCurrentPage] = useState<Page>('map')
 
   const toggleSource = (sourceId: string) => {
     setEnabledSourceIds((prev) => {
@@ -48,6 +53,10 @@ export function DataProvider({ children }: { children: ReactNode }) {
     setShowActiveOnlyState(active)
   }
 
+  const navigateToPage = (page: Page) => {
+    setCurrentPage(page)
+  }
+
   const value: DataContextValue = {
     selectedNode,
     setSelectedNode,
@@ -60,6 +69,8 @@ export function DataProvider({ children }: { children: ReactNode }) {
     setActiveHours,
     onlineHours,
     setOnlineHours,
+    currentPage,
+    navigateToPage,
   }
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>


### PR DESCRIPTION
## Summary

- Add "More Info" button to node popup on map that navigates to Node Details page
- Persist Node Details time selection dropdown to localStorage

## Changes

- **DataContext.tsx**: Added `currentPage` and `navigateToPage` for app-wide navigation
- **Layout.tsx**: Uses DataContext for page navigation instead of local state
- **NavSidebar.tsx**: Imports `Page` type from DataContext
- **MapContainer.tsx**: Added "More Info" button to popup that sets selected node and navigates to Node Details
- **NodeDetailsPanel.tsx**: Time selection now persists to localStorage

## Test plan

- [ ] Click on a node on the map, verify popup shows "More Info" button
- [ ] Click "More Info", verify it navigates to Node Details with that node selected
- [ ] Change time selection on Node Details page, refresh, verify selection is remembered

🤖 Generated with [Claude Code](https://claude.com/claude-code)