### PR TITLE
fix: Correct solar forecast display for voltage-based nodes

### DIFF
--- a/frontend/src/components/Analysis/SolarMonitoring.tsx
+++ b/frontend/src/components/Analysis/SolarMonitoring.tsx
@@ -1012,7 +1012,10 @@ function SolarNodeCard({
                           return [`${(value as number).toFixed(0)} Wh`, 'Forecast Solar']
                         }
                         if (name === 'forecastBattery') {
-                          return [`${value}%`, 'Forecast Battery']
+                          return [
+                            node.metric_type === 'battery' ? `${value}%` : `${(value as number).toFixed(2)}V`,
+                            node.metric_type === 'battery' ? 'Forecast Battery' : 'Forecast Voltage',
+                          ]
                         }
                         if (name === 'value') {
                           return [
@@ -1065,7 +1068,8 @@ function SolarNodeCard({
                       />
                     )}
                     {/* Forecast battery line - dashed orange for visibility */}
-                    {hasForecastData && (
+                    {/* Only show for battery nodes - voltage/INA forecasts use battery % which doesn't match chart scale */}
+                    {hasForecastData && node.metric_type === 'battery' && (
                       <Line
                         yAxisId="left"
                         type="monotone"
@@ -1078,11 +1082,11 @@ function SolarNodeCard({
                         isAnimationActive={false}
                       />
                     )}
-                    {/* 50% warning line for battery forecast when node is at risk */}
+                    {/* Warning line at risk threshold (40% for battery) */}
                     {hasForecastData && node.metric_type === 'battery' && (
                       <ReferenceLine
                         yAxisId="left"
-                        y={50}
+                        y={40}
                         stroke="#ef4444"
                         strokeDasharray="3 3"
                       />


### PR DESCRIPTION
## Summary
- Fix solar forecast display for voltage-based nodes (like Dickfer-3) which were showing mismatched scales
- Voltage nodes now correctly hide the forecast line since simulation uses battery % but chart shows voltage
- Update at-risk threshold to 40% for battery nodes, exclude voltage/INA nodes from at-risk flagging

## Problem
Voltage-based nodes were showing a forecast line with battery percentage values (0-100%) overlaid on a chart displaying actual voltage values (e.g., 4.2V). This caused visual confusion with mismatched Y-axis scales.

## Changes
- Backend: Track `chosen_metric_type`, add `metric_type` and `at_risk_threshold` to API response
- Backend: Only flag battery-based nodes as at-risk (40% threshold)
- Frontend: Only show forecast line for battery nodes
- Frontend: Fix tooltip to show correct labels based on metric type
- Frontend: Update reference line to 40% threshold

## Test plan
- [ ] Verify voltage-based nodes (like Dickfer-3) no longer show forecast line
- [ ] Verify battery-based nodes still show forecast line with correct 40% threshold
- [ ] Verify at-risk warnings only apply to battery-based nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)