### PR TITLE
feat: Add ARM64 support to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., 0.3.1-test)'
+        required: true
+        default: 'test'
 
 env:
   REGISTRY: ghcr.io
@@ -36,8 +42,13 @@ jobs:
       - name: Extract version and set image prefix
         id: version
         run: |
-          # Remove 'v' prefix if present (e.g., v0.1.0 -> 0.1.0)
-          VERSION=${GITHUB_REF_NAME#v}
+          # Use workflow_dispatch input if provided, otherwise use release tag
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            # Remove 'v' prefix if present (e.g., v0.1.0 -> 0.1.0)
+            VERSION=${GITHUB_REF_NAME#v}
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           # Lowercase the repository name for Docker
           IMAGE_PREFIX=$(echo "${{ github.repository_owner }}/meshmanager" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Summary
- Add QEMU setup for cross-platform emulation
- Build multi-arch images (linux/amd64, linux/arm64) for both backend and frontend
- Add `workflow_dispatch` trigger for manual testing with custom version tags
- Update job summary to show supported platforms

## Test plan
- [ ] Merge PR
- [ ] Go to Actions tab → Release workflow → "Run workflow"
- [ ] Enter a test version (e.g., `0.3.1-test`)
- [ ] Verify both amd64 and arm64 images are built and pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)