### PR TITLE
chore: Bump version to 0.4.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.1.0"
+version = "0.4.0"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump frontend version from 0.3.0 to 0.4.0
- Bump backend version from 0.1.0 to 0.4.0 (aligned with frontend)

## Test Results
- Backend: 49 passed, 24 skipped
- Frontend: 84 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)