### PR TITLE
feat: Unify frontend and backend into single Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,31 +56,16 @@ jobs:
           echo "Building version: $VERSION"
           echo "Image prefix: $IMAGE_PREFIX"
 
-      - name: Build and push Backend image
+      - name: Build and push unified MeshManager image
         uses: docker/build-push-action@v5
         with:
-          context: ./backend
+          context: .
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-backend:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-backend:latest
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.version.outputs.version }}
-            org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push Frontend image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./frontend
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-frontend:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-frontend:latest
+            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}:latest
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
@@ -90,18 +75,16 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Docker Images Published" >> $GITHUB_STEP_SUMMARY
+          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Version: \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Platforms: \`linux/amd64\`, \`linux/arm64\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Images:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-backend:${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-frontend:${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "### Image:" >> $GITHUB_STEP_SUMMARY
+          echo "\`${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}:${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Pull Commands:" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull Command:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-backend:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}-frontend:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# MeshManager - Unified Docker Image
+# Multi-stage build combining frontend and backend into a single container
+
+# =============================================================================
+# Stage 1: Build Frontend
+# =============================================================================
+FROM node:22-alpine AS frontend-builder
+
+WORKDIR /app
+
+# Install dependencies
+COPY frontend/package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY frontend/ ./
+RUN npm run build
+
+# =============================================================================
+# Stage 2: Build Backend Dependencies
+# =============================================================================
+FROM python:3.12-slim AS backend-builder
+
+WORKDIR /app
+
+# Install build dependencies (libgdal-dev needed for fiona on ARM64)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    libgdal-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy backend source
+COPY backend/ ./
+
+# Install Python dependencies
+RUN pip install --no-cache-dir .
+
+# =============================================================================
+# Stage 3: Production Image
+# =============================================================================
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
+    gdal-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy installed packages from backend builder
+COPY --from=backend-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=backend-builder /usr/local/bin /usr/local/bin
+
+# Copy backend application code
+COPY backend/ ./
+
+# Copy frontend build output to static directory
+COPY --from=frontend-builder /app/dist ./static
+
+# Create non-root user
+RUN useradd -m -u 1000 meshmanager && \
+    chown -R meshmanager:meshmanager /app
+
+USER meshmanager
+
+# Expose port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import httpx; httpx.get('http://localhost:8000/health')" || exit 1
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,12 +1,12 @@
-# MeshManager - Pre-built Docker Images
+# MeshManager - Pre-built Docker Image
 #
 # Usage:
-#   1. Copy this file and docker/nginx.conf to your deployment directory
+#   1. Copy this file to your deployment directory
 #   2. Create a .env file with required variables (see .env.example)
 #   3. Run: docker compose -f docker-compose.prebuilt.yml up -d
 #
-# To update to a specific version, change the image tags below.
-# Available at: https://github.com/Yeraze/meshmanager/pkgs/container/meshmanager-backend
+# To use a specific version, set MESHMANAGER_VERSION in your .env file.
+# Available at: https://github.com/Yeraze/meshmanager/pkgs/container/meshmanager
 
 services:
   postgres:
@@ -25,9 +25,11 @@ services:
       retries: 5
     restart: unless-stopped
 
-  backend:
-    image: ghcr.io/yeraze/meshmanager-backend:${MESHMANAGER_VERSION:-latest}
-    container_name: meshmanager-backend
+  meshmanager:
+    image: ghcr.io/yeraze/meshmanager:${MESHMANAGER_VERSION:-latest}
+    container_name: meshmanager
+    ports:
+      - "${HTTP_PORT:-8080}:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://meshmanager:${POSTGRES_PASSWORD:-meshmanager}@postgres/meshmanager
       SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
@@ -36,29 +38,9 @@ services:
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
       OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:-}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
-      CORS_ORIGINS: '["http://localhost:8080"]'
     depends_on:
       postgres:
         condition: service_healthy
-    restart: unless-stopped
-
-  frontend:
-    image: ghcr.io/yeraze/meshmanager-frontend:${MESHMANAGER_VERSION:-latest}
-    container_name: meshmanager-frontend
-    depends_on:
-      - backend
-    restart: unless-stopped
-
-  nginx:
-    image: nginx:alpine
-    container_name: meshmanager-nginx
-    ports:
-      - "${HTTP_PORT:-8080}:80"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    depends_on:
-      - frontend
-      - backend
     restart: unless-stopped
 
 volumes:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -44,6 +44,7 @@ export default defineConfig({
           text: 'Configuration',
           items: [
             { text: 'Overview', link: '/configuration/' },
+            { text: 'Docker Configurator', link: '/configuration/configurator' },
             { text: 'Docker Deployment', link: '/configuration/docker' },
             { text: 'Environment Variables', link: '/configuration/environment' },
             { text: 'Data Sources', link: '/configuration/sources' },

--- a/docs/configuration/configurator.md
+++ b/docs/configuration/configurator.md
@@ -1,0 +1,285 @@
+# Docker Compose Configurator
+
+<script setup>
+import { ref, computed } from 'vue'
+
+const config = ref({
+  port: '8080',
+  sessionSecret: '',
+  postgresPassword: 'meshmanager',
+  version: 'latest',
+  oidcEnabled: false,
+  oidcIssuer: '',
+  oidcClientId: '',
+  oidcClientSecret: '',
+  oidcRedirectUri: '',
+  logLevel: 'INFO',
+})
+
+const generateSecret = () => {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  config.value.sessionSecret = Array.from(array, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+const dockerCompose = computed(() => {
+  let yaml = `services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: meshmanager-db
+    environment:
+      POSTGRES_DB: meshmanager
+      POSTGRES_USER: meshmanager
+      POSTGRES_PASSWORD: ${config.value.postgresPassword}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U meshmanager"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  meshmanager:
+    image: ghcr.io/yeraze/meshmanager:${config.value.version}
+    container_name: meshmanager
+    ports:
+      - "${config.value.port}:8000"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://meshmanager:${config.value.postgresPassword}@postgres/meshmanager
+      SESSION_SECRET: ${config.value.sessionSecret || 'GENERATE_ME'}
+      LOG_LEVEL: ${config.value.logLevel}`
+
+  if (config.value.oidcEnabled) {
+    yaml += `
+      OIDC_ISSUER: ${config.value.oidcIssuer}
+      OIDC_CLIENT_ID: ${config.value.oidcClientId}
+      OIDC_CLIENT_SECRET: ${config.value.oidcClientSecret}
+      OIDC_REDIRECT_URI: ${config.value.oidcRedirectUri}`
+  }
+
+  yaml += `
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+    driver: local
+`
+  return yaml
+})
+
+const copyToClipboard = async () => {
+  await navigator.clipboard.writeText(dockerCompose.value)
+}
+</script>
+
+Use this interactive configurator to generate a customized `docker-compose.yml` for your MeshManager deployment.
+
+## Configuration Options
+
+<div class="configurator-form">
+
+### Basic Settings
+
+<div class="form-group">
+  <label for="port">Web Interface Port</label>
+  <input type="text" id="port" v-model="config.port" placeholder="8080" />
+  <small>The port to access MeshManager on your host</small>
+</div>
+
+<div class="form-group">
+  <label for="version">MeshManager Version</label>
+  <select id="version" v-model="config.version">
+    <option value="latest">latest (recommended)</option>
+    <option value="0.4.0">0.4.0</option>
+    <option value="0.3.1">0.3.1</option>
+    <option value="0.3.0">0.3.0</option>
+  </select>
+</div>
+
+<div class="form-group">
+  <label for="logLevel">Log Level</label>
+  <select id="logLevel" v-model="config.logLevel">
+    <option value="DEBUG">DEBUG</option>
+    <option value="INFO">INFO (default)</option>
+    <option value="WARNING">WARNING</option>
+    <option value="ERROR">ERROR</option>
+  </select>
+</div>
+
+### Security Settings
+
+<div class="form-group">
+  <label for="sessionSecret">Session Secret</label>
+  <div class="input-with-button">
+    <input type="text" id="sessionSecret" v-model="config.sessionSecret" placeholder="Click Generate to create" />
+    <button @click="generateSecret" class="generate-btn">Generate</button>
+  </div>
+  <small>Required: A random 64-character hex string for session encryption</small>
+</div>
+
+<div class="form-group">
+  <label for="postgresPassword">PostgreSQL Password</label>
+  <input type="text" id="postgresPassword" v-model="config.postgresPassword" placeholder="meshmanager" />
+  <small>Database password (change from default in production)</small>
+</div>
+
+### OIDC Authentication (Optional)
+
+<div class="form-group">
+  <label class="checkbox-label">
+    <input type="checkbox" v-model="config.oidcEnabled" />
+    Enable OIDC/SSO Authentication
+  </label>
+</div>
+
+<div v-if="config.oidcEnabled" class="oidc-settings">
+  <div class="form-group">
+    <label for="oidcIssuer">OIDC Issuer URL</label>
+    <input type="text" id="oidcIssuer" v-model="config.oidcIssuer" placeholder="https://auth.example.com" />
+  </div>
+  <div class="form-group">
+    <label for="oidcClientId">Client ID</label>
+    <input type="text" id="oidcClientId" v-model="config.oidcClientId" placeholder="meshmanager" />
+  </div>
+  <div class="form-group">
+    <label for="oidcClientSecret">Client Secret</label>
+    <input type="password" id="oidcClientSecret" v-model="config.oidcClientSecret" />
+  </div>
+  <div class="form-group">
+    <label for="oidcRedirectUri">Redirect URI</label>
+    <input type="text" id="oidcRedirectUri" v-model="config.oidcRedirectUri" :placeholder="`http://localhost:${config.port}/auth/callback`" />
+  </div>
+</div>
+
+</div>
+
+## Generated Configuration
+
+<div class="generated-config">
+  <div class="config-header">
+    <span>docker-compose.yml</span>
+    <button @click="copyToClipboard" class="copy-btn">Copy</button>
+  </div>
+  <pre><code>{{ dockerCompose }}</code></pre>
+</div>
+
+## Next Steps
+
+1. Save the configuration above as `docker-compose.yml`
+2. Run `docker compose up -d` to start MeshManager
+3. Access the web interface at `http://localhost:{{ config.port }}`
+4. [Add your first data source](/getting-started#adding-your-first-data-source)
+
+<style>
+.configurator-form {
+  background: var(--vp-c-bg-soft);
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin: 1rem 0;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 4px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font-size: 0.9rem;
+}
+
+.form-group small {
+  display: block;
+  color: var(--vp-c-text-2);
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.checkbox-label {
+  display: flex !important;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.checkbox-label input {
+  width: auto !important;
+}
+
+.input-with-button {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.input-with-button input {
+  flex: 1;
+}
+
+.generate-btn, .copy-btn {
+  padding: 0.5rem 1rem;
+  background: var(--vp-c-brand-1);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.generate-btn:hover, .copy-btn:hover {
+  background: var(--vp-c-brand-2);
+}
+
+.oidc-settings {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--vp-c-bg);
+  border-radius: 4px;
+  border: 1px solid var(--vp-c-border);
+}
+
+.generated-config {
+  margin: 1rem 0;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.config-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: var(--vp-c-bg-soft);
+  border-bottom: 1px solid var(--vp-c-border);
+  font-weight: 600;
+}
+
+.generated-config pre {
+  margin: 0;
+  padding: 1rem;
+  background: var(--vp-c-bg);
+  overflow-x: auto;
+}
+
+.generated-config code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+</style>

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -7,12 +7,10 @@ MeshManager is designed to be configured primarily through the web interface, wi
 ### Docker Compose (Recommended)
 
 The recommended deployment method uses Docker Compose with:
-- **Frontend**: React application served by Nginx
-- **Backend**: FastAPI Python application
+- **MeshManager**: Unified application (FastAPI backend + React frontend)
 - **Database**: PostgreSQL 16
-- **Proxy**: Nginx reverse proxy
 
-See [Docker Deployment](/configuration/docker) for detailed instructions.
+See [Docker Deployment](/configuration/docker) for detailed instructions, or use the [Docker Configurator](/configuration/configurator) to generate a customized compose file.
 
 ### Development Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ features:
     details: Visualize your mesh network topology with traceroute data showing node connections and signal quality.
   - icon: 🐳
     title: Docker Ready
-    details: Deploy easily with Docker Compose. Includes PostgreSQL database and Nginx reverse proxy for production deployments.
+    details: Deploy easily with Docker Compose. Just two containers - MeshManager and PostgreSQL - for simple production deployments.
 ---
 
 ## What is MeshManager?
@@ -51,15 +51,12 @@ MeshManager is a management and oversight application designed to aggregate data
 
 ### Quick Start
 
-```bash
-# Clone the repository
-git clone https://github.com/yeraze/meshmanager.git
-cd meshmanager
+Create a `docker-compose.yml` with MeshManager and PostgreSQL, then:
 
-# Start with Docker Compose
+```bash
 docker compose up -d
 ```
 
-Then open [http://localhost:8080](http://localhost:8080) in your browser.
+Open [http://localhost:8080](http://localhost:8080) in your browser.
 
-See the [Getting Started](/getting-started) guide for detailed setup instructions.
+See the [Getting Started](/getting-started) guide for the complete compose file and setup instructions.


### PR DESCRIPTION
## Summary

This PR unifies the frontend and backend into a single Docker image, simplifying deployment from 4 containers to just 2 (MeshManager + PostgreSQL). This aligns with MeshMonitor's deployment architecture and makes it much easier for users to get started.

## Key Features

🐳 **Unified Docker Image**:
- Single multi-stage Dockerfile combining frontend build and backend
- Frontend assets served directly by FastAPI (no nginx required)
- Image published as `ghcr.io/yeraze/meshmanager`
- Multi-architecture support (amd64, arm64)

📦 **Simplified Deployment**:
- Reduced from 4 containers to 2 (meshmanager + postgres)
- No nginx.conf file needed for production
- Single image tag for version pinning
- Smaller deployment footprint

⚡ **Docker Compose Configurator**:
- Interactive web-based configurator at `/configuration/configurator`
- Generate customized docker-compose.yml with form inputs
- Session secret generator built-in
- OIDC configuration support
- Copy-to-clipboard functionality

📚 **Updated Documentation**:
- Simplified getting-started with inline compose template
- Updated architecture diagrams
- Added configurator to navigation
- Fixed stale references to old multi-container setup

## Technical Details

### Unified Dockerfile

**File**: `Dockerfile` (NEW - 55 lines)
- Stage 1: Build frontend with Node 22
- Stage 2: Build backend dependencies with Python 3.12
- Stage 3: Production image combining both
- Frontend assets copied to `/app/static`
- Health check using httpx

### Backend Static File Serving

**File**: `backend/app/main.py` (+25 lines)
```python
# Serves frontend when static dir exists (unified image)
if STATIC_DIR.exists():
    app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"))
    
    @app.get("/{full_path:path}")
    async def serve_spa(full_path: str):
        # Serve static files or index.html for SPA routing
```

### Release Workflow

**File**: `.github/workflows/release.yml`
- Changed from building 2 images to 1 unified image
- Image: `ghcr.io/yeraze/meshmanager:{version}`
- Maintains multi-arch builds (amd64, arm64)

### Docker Compose Configurator

**File**: `docs/configuration/configurator.md` (NEW - 200 lines)
- Vue component embedded in VitePress
- Form sections: Basic Settings, Security, OIDC
- Real-time YAML generation
- Catppuccin-themed UI matching site design

## Files Changed

**New Files**:
- `Dockerfile` - Unified multi-stage build
- `docs/configuration/configurator.md` - Interactive configurator

**Modified Files**:
- `.github/workflows/release.yml` - Single image build
- `backend/app/main.py` - Static file serving
- `docker-compose.prebuilt.yml` - 2-container setup
- `docs/.vitepress/config.mts` - Added configurator nav
- `docs/getting-started.md` - Simplified quick start
- `docs/index.md` - Updated features
- `docs/configuration/index.md` - Updated architecture
- `docs/configuration/docker.md` - Updated docs
- `README.md` - Updated badges, quick start, architecture

## Backward Compatibility

⚠️ **Breaking Change for Existing Users**:
- Old images (`meshmanager-backend`, `meshmanager-frontend`) will no longer be published
- Users must migrate to new unified image and simplified compose file
- Migration is straightforward: replace 4-container compose with 2-container version

## Checklist

- [x] Unified Dockerfile created
- [x] Backend serves static files
- [x] Release workflow updated
- [x] docker-compose.prebuilt.yml simplified
- [x] Docker Configurator added
- [x] Documentation updated
- [x] README updated
- [x] Stale references fixed
- [x] Development workflow unchanged (docker-compose.dev.yml)