### PR TITLE
fix: Disable provenance for manifest-compatible images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
+          # Disable provenance to create simple images (not manifest lists)
+          # This allows docker manifest create to combine them later
+          provenance: false
           tags: |
             ${{ env.REGISTRY }}/${{ steps.version.outputs.image_prefix }}:${{ steps.version.outputs.version }}-${{ matrix.suffix }}
           labels: |


### PR DESCRIPTION
## Summary
Fix manifest creation failure in parallel Docker builds.

## Problem
`docker manifest create` failed with: `ghcr.io/yeraze/meshmanager:0.5.0-amd64 is a manifest list`

Build-push-action v6 creates manifest lists with attestations by default, which can't be combined with `docker manifest create`.

## Solution
Add `provenance: false` to create simple platform images that can be combined into a multi-arch manifest.

## Test plan
- [ ] Re-run release workflow
- [ ] Verify manifest creation succeeds
- [ ] Verify multi-arch image works on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)