### PR TITLE
fix: Use v1 API for MeshMonitor node collection

### DIFF
--- a/backend/app/collectors/meshmonitor.py
+++ b/backend/app/collectors/meshmonitor.py
@@ -320,14 +320,22 @@ class MeshMonitorCollector(BaseCollector):
             node.long_name = long_name
             node.hw_model = hw_model
             node.role = role
-            node.latitude = position.get("latitude") or position.get("lat")
-            node.longitude = position.get("longitude") or position.get("lon")
-            node.altitude = position.get("altitude") or position.get("alt")
+            # Only update position if new data has it (don't overwrite with None)
+            new_lat = position.get("latitude") or position.get("lat")
+            new_lon = position.get("longitude") or position.get("lon")
+            new_alt = position.get("altitude") or position.get("alt")
+            if new_lat is not None:
+                node.latitude = new_lat
+            if new_lon is not None:
+                node.longitude = new_lon
+            if new_alt is not None:
+                node.altitude = new_alt
             if position.get("time"):
                 node.position_time = datetime.fromtimestamp(
                     position["time"], tz=UTC
                 )
-            node.position_precision_bits = position.get("precisionBits")
+            if position.get("precisionBits") is not None:
+                node.position_precision_bits = position.get("precisionBits")
             node.snr = snr
             node.rssi = rssi
             node.hops_away = hops_away


### PR DESCRIPTION
## Summary
Fixes nodes not appearing on the map when MeshMonitor requires v1 API authentication.

## Problem
The `_collect_nodes()` function was using the old `/api/nodes` endpoint instead of the token-authenticated `/api/v1/nodes` endpoint. When MeshMonitor enforces v1 API authentication, nodes fail to collect (401/403), causing an empty map.

## Changes
- `test_connection()`: Use `/api/v1/nodes` with `data.get("data", [])`
- `_collect_nodes()`: Use `/api/v1/nodes` with `data.get("data", [])`

## Test plan
- [ ] Deploy to environment with MeshMonitor using v1 API auth
- [ ] Verify nodes appear on map
- [ ] Verify "Test Connection" works for MeshMonitor sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)