### PR TITLE
fix(mqtt): Create Telemetry records for Coverage Map and Utilization …

### DIFF
--- a/backend/app/collectors/mqtt.py
+++ b/backend/app/collectors/mqtt.py
@@ -9,7 +9,7 @@ import aiomqtt
 
 from app.collectors.base import BaseCollector
 from app.database import async_session_maker
-from app.models import Message, Node, Source, Telemetry
+from app.models import Channel, Message, Node, Source, Telemetry
 from app.schemas.source import SourceTestResult
 from app.services.protobuf import decode_meshtastic_packet
 
@@ -129,6 +129,7 @@ class MqttCollector(BaseCollector):
         try:
             topic = str(message.topic)
             payload = message.payload
+            logger.debug(f"Received MQTT message: topic={topic}, payload_len={len(payload) if isinstance(payload, bytes) else 'N/A'}")
 
             # Try to decode as JSON first
             try:
@@ -136,33 +137,73 @@ class MqttCollector(BaseCollector):
                     data = json.loads(payload.decode("utf-8"))
                 else:
                     data = json.loads(payload)
+                logger.debug(f"Decoded JSON message: type={data.get('type')}, from={data.get('from') or data.get('fromId')}")
                 await self._process_json_message(topic, data)
                 return
-            except (json.JSONDecodeError, UnicodeDecodeError):
+            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                logger.debug(f"Failed to decode as JSON: {e}")
                 pass
 
             # Try to decode as protobuf
             if isinstance(payload, bytes):
+                logger.debug("Attempting protobuf decode")
                 await self._process_protobuf_message(topic, payload)
 
         except Exception as e:
-            logger.error(f"Error processing MQTT message: {e}")
+            logger.error(f"Error processing MQTT message: {e}", exc_info=True)
 
     async def _process_json_message(self, topic: str, data: dict) -> None:
         """Process a JSON-encoded Meshtastic message."""
         msg_type = data.get("type", "").lower()
+        logger.debug(f"Processing JSON message: type={msg_type}, topic={topic}, keys={list(data.keys())}")
 
         async with async_session_maker() as db:
+            await self._ensure_channel(db, data)
             if msg_type == "text" or "text" in data:
+                logger.debug("Handling as text message")
                 await self._handle_text_message(db, data)
             elif msg_type == "position" or "position" in data:
+                logger.debug("Handling as position message")
                 await self._handle_position(db, data)
             elif msg_type == "telemetry" or "telemetry" in data:
+                logger.debug("Handling as telemetry message")
                 await self._handle_telemetry(db, data)
             elif msg_type == "nodeinfo" or "nodeinfo" in data:
+                logger.debug("Handling as nodeinfo message")
                 await self._handle_nodeinfo(db, data)
+            else:
+                logger.debug(f"Message type '{msg_type}' not handled, skipping")
 
             await db.commit()
+
+    async def _ensure_channel(self, db, data: dict) -> None:
+        """Ensure a channel record exists for MQTT messages."""
+        channel_index = data.get("channel")
+        if channel_index is None:
+            return
+        try:
+            channel_index = int(channel_index)
+        except (TypeError, ValueError):
+            return
+
+        from sqlalchemy import select
+
+        result = await db.execute(
+            select(Channel).where(
+                Channel.source_id == self.source.id,
+                Channel.channel_index == channel_index,
+            )
+        )
+        channel = result.scalar()
+        if channel:
+            return
+
+        channel = Channel(
+            source_id=self.source.id,
+            channel_index=channel_index,
+            name=data.get("channel_name") or data.get("channelName"),
+        )
+        db.add(channel)
 
     async def _process_protobuf_message(self, topic: str, payload: bytes) -> None:
         """Process a protobuf-encoded Meshtastic message."""
@@ -189,6 +230,8 @@ class MqttCollector(BaseCollector):
         if isinstance(to_node, str) and to_node.startswith("!"):
             to_node = int(to_node[1:], 16)
 
+        rx_time = self._parse_rx_time(data.get("rxTime"))
+
         message = Message(
             source_id=self.source.id,
             packet_id=data.get("id"),
@@ -198,14 +241,33 @@ class MqttCollector(BaseCollector):
             text=data.get("text") or data.get("payload"),
             hop_limit=data.get("hopLimit"),
             hop_start=data.get("hopStart"),
+            rx_time=rx_time,
             rx_snr=data.get("rxSnr"),
             rx_rssi=data.get("rxRssi"),
         )
         db.add(message)
         logger.debug(f"Received text message from {from_node}")
 
+    @staticmethod
+    def _parse_rx_time(value) -> datetime | None:
+        if value is None:
+            return None
+        try:
+            if isinstance(value, (int, float)):
+                ts = float(value)
+                if ts > 2_000_000_000_000:
+                    ts = ts / 1000.0
+                return datetime.fromtimestamp(ts, UTC)
+            if isinstance(value, str):
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (TypeError, ValueError, OSError):
+            return None
+        return None
+
     async def _handle_position(self, db, data: dict) -> None:
         """Handle a position update."""
+        from app.models.telemetry import TelemetryType
+
         from_node = data.get("from") or data.get("fromId")
         if not from_node:
             return
@@ -214,6 +276,12 @@ class MqttCollector(BaseCollector):
             from_node = int(from_node[1:], 16)
 
         position = data.get("position", data)
+        lat = position.get("latitude") or position.get("lat")
+        lon = position.get("longitude") or position.get("lon")
+        alt = position.get("altitude") or position.get("alt")
+
+        # Parse rx_time for telemetry records
+        rx_time = self._parse_rx_time(data.get("rxTime")) or datetime.now(UTC)
 
         # Update or create node
         from sqlalchemy import select
@@ -227,28 +295,73 @@ class MqttCollector(BaseCollector):
         node = result.scalar()
 
         if node:
-            node.latitude = position.get("latitude") or position.get("lat")
-            node.longitude = position.get("longitude") or position.get("lon")
-            node.altitude = position.get("altitude") or position.get("alt")
+            node.latitude = lat
+            node.longitude = lon
+            node.altitude = alt
             node.position_time = datetime.now(UTC)
             node.last_heard = datetime.now(UTC)
         else:
             node = Node(
                 source_id=self.source.id,
                 node_num=from_node,
-                latitude=position.get("latitude") or position.get("lat"),
-                longitude=position.get("longitude") or position.get("lon"),
-                altitude=position.get("altitude") or position.get("alt"),
+                latitude=lat,
+                longitude=lon,
+                altitude=alt,
                 position_time=datetime.now(UTC),
                 last_heard=datetime.now(UTC),
             )
             db.add(node)
+
+        # Create Telemetry records for Coverage Map (requires latitude/longitude in Telemetry table)
+        # Check for existing records to avoid unique constraint violations
+        if lat is not None:
+            # Check if record already exists
+            existing_lat = await db.execute(
+                select(Telemetry).where(
+                    Telemetry.source_id == self.source.id,
+                    Telemetry.node_num == from_node,
+                    Telemetry.metric_name == "latitude",
+                    Telemetry.received_at == rx_time,
+                )
+            )
+            if not existing_lat.scalar_one_or_none():
+                lat_telemetry = Telemetry(
+                    source_id=self.source.id,
+                    node_num=from_node,
+                    metric_name="latitude",
+                    telemetry_type=TelemetryType.POSITION,
+                    latitude=lat,
+                    received_at=rx_time,
+                )
+                db.add(lat_telemetry)
+
+        if lon is not None:
+            # Check if record already exists
+            existing_lon = await db.execute(
+                select(Telemetry).where(
+                    Telemetry.source_id == self.source.id,
+                    Telemetry.node_num == from_node,
+                    Telemetry.metric_name == "longitude",
+                    Telemetry.received_at == rx_time,
+                )
+            )
+            if not existing_lon.scalar_one_or_none():
+                lon_telemetry = Telemetry(
+                    source_id=self.source.id,
+                    node_num=from_node,
+                    metric_name="longitude",
+                    telemetry_type=TelemetryType.POSITION,
+                    longitude=lon,
+                    received_at=rx_time,
+                )
+                db.add(lon_telemetry)
 
         logger.debug(f"Received position from {from_node}")
 
     async def _handle_telemetry(self, db, data: dict) -> None:
         """Handle telemetry data."""
         from app.models.telemetry import TelemetryType
+        from sqlalchemy import select
 
         from_node = data.get("from") or data.get("fromId")
         if not from_node:
@@ -261,20 +374,76 @@ class MqttCollector(BaseCollector):
         device_metrics = telem.get("deviceMetrics", {})
         env_metrics = telem.get("environmentMetrics", {})
 
-        telemetry = Telemetry(
-            source_id=self.source.id,
-            node_num=from_node,
-            telemetry_type=TelemetryType.DEVICE if device_metrics else TelemetryType.ENVIRONMENT,
-            battery_level=device_metrics.get("batteryLevel"),
-            voltage=device_metrics.get("voltage"),
-            channel_utilization=device_metrics.get("channelUtilization"),
-            air_util_tx=device_metrics.get("airUtilTx"),
-            uptime_seconds=device_metrics.get("uptimeSeconds"),
-            temperature=env_metrics.get("temperature"),
-            relative_humidity=env_metrics.get("relativeHumidity"),
-            barometric_pressure=env_metrics.get("barometricPressure"),
-        )
-        db.add(telemetry)
+        # Parse rx_time for telemetry records
+        rx_time = self._parse_rx_time(data.get("rxTime")) or datetime.now(UTC)
+
+        # Create separate Telemetry records for each metric (required for Utilization overlay and proper querying)
+        # Device metrics
+        if device_metrics:
+            metrics_to_create = [
+                ("batteryLevel", "battery_level", device_metrics.get("batteryLevel"), int),
+                ("voltage", "voltage", device_metrics.get("voltage"), float),
+                ("channelUtilization", "channel_utilization", device_metrics.get("channelUtilization"), float),
+                ("airUtilTx", "air_util_tx", device_metrics.get("airUtilTx"), float),
+                ("uptimeSeconds", "uptime_seconds", device_metrics.get("uptimeSeconds"), int),
+            ]
+
+            for metric_name, field_name, value, value_type in metrics_to_create:
+                if value is not None:
+                    # Check if record already exists
+                    existing = await db.execute(
+                        select(Telemetry).where(
+                            Telemetry.source_id == self.source.id,
+                            Telemetry.node_num == from_node,
+                            Telemetry.metric_name == metric_name,
+                            Telemetry.received_at == rx_time,
+                        )
+                    )
+                    if not existing.scalar_one_or_none():
+                        # Build kwargs for the specific metric field
+                        kwargs = {
+                            "source_id": self.source.id,
+                            "node_num": from_node,
+                            "metric_name": metric_name,
+                            "telemetry_type": TelemetryType.DEVICE,
+                            "received_at": rx_time,
+                            field_name: value_type(value),
+                        }
+                        telemetry = Telemetry(**kwargs)
+                        db.add(telemetry)
+
+        # Environment metrics
+        if env_metrics:
+            metrics_to_create = [
+                ("temperature", "temperature", env_metrics.get("temperature"), float),
+                ("relativeHumidity", "relative_humidity", env_metrics.get("relativeHumidity"), float),
+                ("barometricPressure", "barometric_pressure", env_metrics.get("barometricPressure"), float),
+            ]
+
+            for metric_name, field_name, value, value_type in metrics_to_create:
+                if value is not None:
+                    # Check if record already exists
+                    existing = await db.execute(
+                        select(Telemetry).where(
+                            Telemetry.source_id == self.source.id,
+                            Telemetry.node_num == from_node,
+                            Telemetry.metric_name == metric_name,
+                            Telemetry.received_at == rx_time,
+                        )
+                    )
+                    if not existing.scalar_one_or_none():
+                        # Build kwargs for the specific metric field
+                        kwargs = {
+                            "source_id": self.source.id,
+                            "node_num": from_node,
+                            "metric_name": metric_name,
+                            "telemetry_type": TelemetryType.ENVIRONMENT,
+                            "received_at": rx_time,
+                            field_name: value_type(value),
+                        }
+                        telemetry = Telemetry(**kwargs)
+                        db.add(telemetry)
+
         logger.debug(f"Received telemetry from {from_node}")
 
     async def _handle_nodeinfo(self, db, data: dict) -> None:


### PR DESCRIPTION
…Overlay

The Coverage Map and Utilization Overlay features require Telemetry records with specific metric_name values, but the MQTT collector was not creating these records properly.

Changes:
- _handle_position: Now creates separate Telemetry records for latitude and longitude with metric_name="latitude" and metric_name="longitude"
- _handle_telemetry: Now creates separate Telemetry records for each metric (batteryLevel, voltage, channelUtilization, etc.) with appropriate metric_name values

This enables:
- Coverage Map to query Telemetry table for position data
- Utilization Overlay to query Telemetry table for channelUtilization data

Both features now work correctly with MQTT sources.