### PR TITLE
fix: Handle flat position fields in v1 API node response

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.5.1"
+version = "0.5.2"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Fix node positions not populating from MeshMonitor v1 API
- The v1 API returns position data as flat top-level fields (`latitude`, `longitude`, `altitude`) rather than nested in a `position` object
- Updated `_upsert_node()` to check for flat fields first, then fall back to nested position object for backwards compatibility
- Bumps version to 0.5.2

## Root Cause
The MeshMonitor v1 API OpenAPI spec shows position fields as flat properties on the Node schema, not nested under a `position` object. Our code was only looking in the nested location, missing the actual data.

Reference: https://github.com/Yeraze/meshmonitor/blob/fad57853f84c96d994549ff461752856ce1bec49/src/server/routes/v1/openapi.yaml

## Test plan
- [ ] CI passes
- [ ] Deploy and verify nodes sync with positions from MeshMonitor v1 API
- [ ] Verify map displays node markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)