### PR TITLE
fix: Use timezone-aware UTC datetimes to prevent MQTT timestamp offset

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,11 +1,17 @@
 """Database connection and session management."""
 
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.config import get_settings
+
+
+def utc_now() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime."""
+    return datetime.now(UTC)
 
 
 class Base(DeclarativeBase):

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -7,7 +7,7 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class Channel(Base):
@@ -37,8 +37,8 @@ class Channel(Base):
 
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     # Relationships

--- a/backend/app/models/coverage.py
+++ b/backend/app/models/coverage.py
@@ -7,7 +7,7 @@ from sqlalchemy import DateTime, Float, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class CoverageCell(Base):
@@ -32,5 +32,5 @@ class CoverageCell(Base):
     # Timestamps
     generated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
     )

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -7,16 +7,14 @@ from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, String,
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class Message(Base):
     """A text message from the mesh network."""
 
     __tablename__ = "messages"
-    __table_args__ = (
-        Index("idx_messages_source_packet", "source_id", "packet_id", unique=True),
-    )
+    __table_args__ = (Index("idx_messages_source_packet", "source_id", "packet_id", unique=True),)
 
     id: Mapped[str] = mapped_column(
         UUID(as_uuid=False),
@@ -31,8 +29,12 @@ class Message(Base):
     )
 
     # Message identification
-    packet_id: Mapped[str | None] = mapped_column(String(64))  # Source-specific ID (composite for MeshMonitor)
-    meshtastic_id: Mapped[int | None] = mapped_column(BigInteger, index=True)  # Raw Meshtastic packet ID
+    packet_id: Mapped[str | None] = mapped_column(
+        String(64)
+    )  # Source-specific ID (composite for MeshMonitor)
+    meshtastic_id: Mapped[int | None] = mapped_column(
+        BigInteger, index=True
+    )  # Raw Meshtastic packet ID
     from_node_num: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
     to_node_num: Mapped[int | None] = mapped_column(BigInteger)
     channel: Mapped[int] = mapped_column(Integer, default=0)
@@ -52,7 +54,7 @@ class Message(Base):
     # Timestamp
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
         index=True,
     )
 

--- a/backend/app/models/node.py
+++ b/backend/app/models/node.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class Node(Base):
@@ -66,17 +66,15 @@ class Node(Base):
     # Timestamps
     first_seen: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     # Relationships
     source: Mapped["Source"] = relationship("Source", back_populates="nodes")  # noqa: F821
 
-    __table_args__ = (
-        UniqueConstraint("source_id", "node_num", name="uq_nodes_source_node"),
-    )
+    __table_args__ = (UniqueConstraint("source_id", "node_num", name="uq_nodes_source_node"),)

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -6,7 +6,7 @@ from sqlalchemy import JSON, DateTime, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class SystemSetting(Base):
@@ -15,11 +15,9 @@ class SystemSetting(Base):
     __tablename__ = "settings"
 
     key: Mapped[str] = mapped_column(String(100), primary_key=True)
-    value: Mapped[dict] = mapped_column(
-        JSON().with_variant(JSONB, "postgresql"), nullable=False
-    )
+    value: Mapped[dict] = mapped_column(JSON().with_variant(JSONB, "postgresql"), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utc_now,
+        onupdate=utc_now,
     )

--- a/backend/app/models/solar_production.py
+++ b/backend/app/models/solar_production.py
@@ -1,13 +1,13 @@
 """Solar production data model for storing hourly watt-hours data."""
 
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import DateTime, Float, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class SolarProduction(Base):
@@ -52,7 +52,7 @@ class SolarProduction(Base):
     # When we received/stored this record
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(UTC),
+        default=utc_now,
         index=True,
     )
 

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -8,7 +8,7 @@ from sqlalchemy import Boolean, DateTime, Enum, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class SourceType(enum.StrEnum):
@@ -35,7 +35,9 @@ class Source(Base):
     url: Mapped[str | None] = mapped_column(String(500))
     api_token: Mapped[str | None] = mapped_column(String(500))
     poll_interval_seconds: Mapped[int] = mapped_column(Integer, default=300)
-    historical_days_back: Mapped[int] = mapped_column(Integer, default=1)  # Days of historical data to sync
+    historical_days_back: Mapped[int] = mapped_column(
+        Integer, default=1
+    )  # Days of historical data to sync
 
     # MQTT specific
     mqtt_host: Mapped[str | None] = mapped_column(String(255))
@@ -52,12 +54,12 @@ class Source(Base):
     remote_version: Mapped[str | None] = mapped_column(String(50))  # Version from remote source
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     # Relationships

--- a/backend/app/models/telemetry.py
+++ b/backend/app/models/telemetry.py
@@ -8,7 +8,7 @@ from sqlalchemy import BigInteger, DateTime, Enum, Float, ForeignKey, Index, Int
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class TelemetryType(enum.StrEnum):
@@ -89,7 +89,7 @@ class Telemetry(Base):
     # Timestamp
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
         index=True,
     )
 

--- a/backend/app/models/traceroute.py
+++ b/backend/app/models/traceroute.py
@@ -1,13 +1,13 @@
 """Traceroute model for route information."""
 
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import BigInteger, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class Traceroute(Base):
@@ -51,7 +51,7 @@ class Traceroute(Base):
     # Timestamp
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(UTC),
+        default=utc_now,
         index=True,
     )
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,7 +7,7 @@ from sqlalchemy import Boolean, DateTime, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class User(Base):
@@ -43,6 +43,6 @@ class User(Base):
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
     )
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/models/utilization.py
+++ b/backend/app/models/utilization.py
@@ -7,7 +7,7 @@ from sqlalchemy import DateTime, Float, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.database import Base
+from app.database import Base, utc_now
 
 
 class UtilizationCell(Base):
@@ -32,5 +32,5 @@ class UtilizationCell(Base):
     # Timestamps
     generated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=utc_now,
     )

--- a/backend/scripts/fix_mqtt_timestamps.py
+++ b/backend/scripts/fix_mqtt_timestamps.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""One-time fix for MQTT message timestamps that were stored 5 hours ahead.
+
+Root cause: datetime.utcnow() returns a naive datetime. asyncpg treats naive
+datetimes as local time (e.g. EST/UTC-5), then converts to UTC for TIMESTAMPTZ
+columns -- adding 5 hours.
+
+This script subtracts 5 hours from all messages that came from MQTT sources.
+
+Usage:
+    docker exec meshmanager-backend-dev python scripts/fix_mqtt_timestamps.py
+"""
+
+import asyncio
+import sys
+
+sys.path.insert(0, "/app")
+
+from sqlalchemy import text
+
+from app.database import async_session_maker
+
+
+async def fix_mqtt_timestamps() -> None:
+    """Subtract 5 hours from MQTT-sourced message timestamps."""
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text("""
+                UPDATE messages
+                SET received_at = received_at - INTERVAL '5 hours'
+                WHERE source_id IN (
+                    SELECT id FROM sources WHERE type = 'MQTT'::sourcetype
+                )
+            """)
+        )
+        await session.commit()
+        print(f"Updated {result.rowcount} MQTT message timestamps.")
+
+
+if __name__ == "__main__":
+    asyncio.run(fix_mqtt_timestamps())


### PR DESCRIPTION
## Summary

- **Root cause**: `datetime.utcnow()` returns naive datetimes (no tzinfo). asyncpg treats these as local time (EST/UTC-5), then converts to UTC for `TIMESTAMPTZ` columns — adding 5 hours to MQTT-sourced timestamps.
- Added centralized `utc_now()` helper in `database.py` returning `datetime.now(UTC)` (timezone-aware)
- Replaced `datetime.utcnow` defaults/onupdates across all 11 model files with `utc_now`
- Includes one-time fix script (`scripts/fix_mqtt_timestamps.py`) to correct existing MQTT data — already run against dev (48 rows corrected)

## Test plan

- [x] `ruff check` passes on all modified files
- [x] `ruff format --check` passes on all modified files
- [x] `pytest tests/ -x` — 77 passed, 24 skipped (pre-existing)
- [x] Dev containers built and deployed successfully
- [x] One-time fix script executed — 48 MQTT message timestamps corrected
- [ ] Verify MQTT vs MeshMonitor timestamps for same `meshtastic_id` now match within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)