### PR TITLE
fix: Filter route segments by enabled sources and fix message timestamp ordering

### DIFF
--- a/frontend/src/components/Map/MapContainer.tsx
+++ b/frontend/src/components/Map/MapContainer.tsx
@@ -479,6 +479,9 @@ export default function MapContainer() {
     }
 
     for (const trace of traceroutes) {
+      // Skip traceroutes from disabled sources
+      if (!enabledSourceIds.has(trace.source_id)) continue
+
       // Skip incomplete traceroutes (no route_back means no response received)
       // These are failed traceroutes that shouldn't be rendered
       if (trace.route_back === null) continue
@@ -512,7 +515,7 @@ export default function MapContainer() {
         usage,
       }
     })
-  }, [traceroutes, nodePositionsByNum, showRoutes])
+  }, [traceroutes, nodePositionsByNum, showRoutes, enabledSourceIds])
 
   return (
     <div className="map-container">


### PR DESCRIPTION
## Summary

- **Map route filtering**: Route segments now respect source toggles — disabling a source hides its traceroute lines alongside its nodes (`MapContainer.tsx`)
- **Message timestamp ordering**: The Communication tab sorted messages by `received_at` (server time) but displayed `rx_time` (device time). When MQTT messages carried stale `rx_time` values, the newest messages appeared under old date headers. The backend now sorts, paginates, and cursors using `COALESCE(rx_time, received_at)` to match the frontend's display logic (`messages.py`)
- **Node join deduplication**: The Node join matched across all sources, producing row multiplication when a node existed in multiple sources. Now joins on `(node_num, source_id)`
- **Source filter leak**: The source-name filter only applied to the dedup subquery, so `DISTINCT ON` could pick a row from a disabled source as the representative. The main query now also filters by source

## Test plan

- [x] Frontend tests pass (95/95)
- [x] Backend tests pass (108/108)
- [x] Built and deployed to dev stack for manual verification
- [ ] Toggle a source off in the map sidebar — its route lines should disappear; toggle back on and they reappear
- [ ] In Communication tab, enable MQTT source — newest messages should display with correct date grouping
- [ ] Disable a source in Communication tab — only messages from enabled sources should appear (no leakage from disabled sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)