### PR TITLE
fix: Decode inner protobuf payloads in MQTT collector

### DIFF
--- a/backend/app/collectors/mqtt.py
+++ b/backend/app/collectors/mqtt.py
@@ -378,8 +378,10 @@ class MqttCollector(BaseCollector):
         int_val = data.get(int_key)
         if int_val is None:
             # camelCase from protobuf MessageToDict: "latitudeI" / "longitudeI"
-            camel_key = int_key.replace("_i", "I")
-            int_val = data.get(camel_key)
+            camel_key_map = {"latitude_i": "latitudeI", "longitude_i": "longitudeI"}
+            camel_key = camel_key_map.get(int_key)
+            if camel_key:
+                int_val = data.get(camel_key)
         if int_val is not None:
             return int(int_val) / 1e7
         return None

--- a/backend/app/services/protobuf.py
+++ b/backend/app/services/protobuf.py
@@ -1,6 +1,7 @@
 """Protobuf decoding for Meshtastic packets."""
 
 import logging
+from typing import Any
 
 from google.protobuf.json_format import MessageToDict
 
@@ -31,8 +32,8 @@ def decode_meshtastic_packet(payload: bytes) -> dict | None:
                 "hopLimit": packet.hop_limit,
                 "hopStart": packet.hop_start,
                 "rxTime": packet.rx_time or None,
-                "rxSnr": packet.rx_snr or None,
-                "rxRssi": packet.rx_rssi or None,
+                "rxSnr": packet.rx_snr,
+                "rxRssi": packet.rx_rssi,
             }
 
             if packet.HasField("decoded"):
@@ -46,7 +47,7 @@ def decode_meshtastic_packet(payload: bytes) -> dict | None:
 
                 # Decode inner payload based on portnum
                 decoded["payload"] = _decode_inner_payload(
-                    portnum, raw_payload, mesh_pb2, telemetry_pb2
+                    portnum, raw_payload, mesh_pb2, portnums_pb2, telemetry_pb2
                 )
 
                 # For TEXT_MESSAGE_APP, also set top-level "text" key
@@ -67,16 +68,15 @@ def decode_meshtastic_packet(payload: bytes) -> dict | None:
 def _decode_inner_payload(
     portnum: int,
     raw_payload: bytes,
-    mesh_pb2,
-    telemetry_pb2,
+    mesh_pb2: Any,
+    portnums_pb2: Any,
+    telemetry_pb2: Any,
 ) -> dict | bytes:
     """Decode the inner payload bytes into a dict based on portnum.
 
     Returns the decoded dict on success, or the original raw bytes if decoding
     fails or the portnum is unrecognized.
     """
-    from meshtastic import portnums_pb2
-
     try:
         if portnum == portnums_pb2.PortNum.POSITION_APP:
             msg = mesh_pb2.Position()


### PR DESCRIPTION
## Summary

- **Decode inner protobuf payloads** (Position, User, Telemetry, RouteDiscovery) into dicts via `MessageToDict` so MQTT handlers receive structured data instead of raw bytes
- **Fix ServiceEnvelope import** — was using `mesh_pb2` (wrong module), now correctly uses `mqtt_pb2`
- **Fix `from` field access** — protobuf reserves `from` as a keyword; switched to `getattr(packet, "from")`
- **Add camelCase integer coordinate keys** (`latitudeI`/`longitudeI`) to `_extract_coordinate` for protobuf-decoded position payloads

## Context

The MQTT protobuf decoder only decoded the outer ServiceEnvelope/MeshPacket but left inner payloads as raw bytes. The MQTT collector handlers then tried to use raw bytes as dicts, failed silently, and dropped all position, nodeinfo, and telemetry data from protobuf-encoded MQTT messages. Only text messages and traceroutes worked. This is why only ~3 nodes (from JSON-decoded topics) appeared instead of hundreds statewide.

## Test plan

- [x] Backend tests pass (`pytest -x -q` — 109 passed)
- [x] Frontend tests pass (`npm test -- --run` — 95 passed)
- [x] Ruff linting passes
- [x] End-to-end protobuf decode verification (Position, Nodeinfo, Telemetry, Text)
- [x] Docker build and deploy — confirmed telemetry inserts and node position updates in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)