### PR TITLE
feat: Decrypt encrypted MQTT packets using channel PSKs

### DIFF
--- a/backend/app/collectors/meshmonitor.py
+++ b/backend/app/collectors/meshmonitor.py
@@ -457,6 +457,7 @@ class MeshMonitorCollector(BaseCollector):
             channel.uplink_enabled = channel_data.get("uplinkEnabled", False)
             channel.downlink_enabled = channel_data.get("downlinkEnabled", False)
             channel.position_precision = channel_data.get("positionPrecision")
+            channel.psk = channel_data.get("psk")
             channel.updated_at = datetime.now(UTC)
         else:
             # Create new channel
@@ -468,6 +469,7 @@ class MeshMonitorCollector(BaseCollector):
                 uplink_enabled=channel_data.get("uplinkEnabled", False),
                 downlink_enabled=channel_data.get("downlinkEnabled", False),
                 position_precision=channel_data.get("positionPrecision"),
+                psk=channel_data.get("psk"),
             )
             db.add(channel)
 

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -34,6 +34,7 @@ class Channel(Base):
     uplink_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     downlink_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     position_precision: Mapped[int | None] = mapped_column(Integer)
+    psk: Mapped[str | None] = mapped_column(String(48))  # base64-encoded AES key
 
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/app/services/protobuf.py
+++ b/backend/app/services/protobuf.py
@@ -1,20 +1,110 @@
 """Protobuf decoding for Meshtastic packets."""
 
+import base64
 import logging
+import struct
 from typing import Any
 
 from google.protobuf.json_format import MessageToDict
 
 logger = logging.getLogger(__name__)
 
+# Meshtastic default channel key (AES-128, "LongFast" / simple key index 1)
+MESHTASTIC_DEFAULT_KEY = base64.b64decode("1PG7OiApB1nwvP+rz05pAQ==")
 
-def decode_meshtastic_packet(payload: bytes) -> dict | None:
+
+def _expand_psk(psk_b64: str) -> bytes | None:
+    """Expand a Meshtastic PSK from base64 to an AES key.
+
+    Meshtastic PSK formats:
+    - Empty / zero byte  -> no encryption, return None
+    - Single byte (1-255)-> replace the last byte of the default key
+    - 16 or 32 bytes     -> use as-is (AES-128 or AES-256)
+    """
+    try:
+        raw = base64.b64decode(psk_b64)
+    except Exception:
+        return None
+
+    if not raw or raw == b"\x00":
+        return None
+
+    if len(raw) == 1:
+        # Single-byte PSK: replace last byte of default key
+        return MESHTASTIC_DEFAULT_KEY[:-1] + raw
+
+    if len(raw) in (16, 32):
+        return raw
+
+    # Unknown length — try using it anyway
+    return raw
+
+
+def _decrypt_packet(
+    encrypted_bytes: bytes,
+    packet_id: int,
+    from_node_num: int,
+    keys: list[bytes],
+) -> Any | None:
+    """Try to decrypt a Meshtastic encrypted packet with a list of AES keys.
+
+    Uses AES-128-CTR (or AES-256-CTR) with a nonce constructed from the
+    packet_id and from_node_num as per the Meshtastic protocol.
+
+    Returns the decoded mesh_pb2.Data message on success, or None.
+    """
+    try:
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    except ImportError:
+        logger.debug("cryptography library not available for decryption")
+        return None
+
+    # Meshtastic nonce: 8 bytes packet_id (little-endian) + 4 bytes from_node (LE) + 4 zero bytes
+    nonce = struct.pack("<QI", packet_id, from_node_num) + b"\x00" * 4
+
+    try:
+        from meshtastic import mesh_pb2
+    except ImportError:
+        return None
+
+    for key in keys:
+        try:
+            cipher = Cipher(algorithms.AES(key), modes.CTR(nonce))
+            decryptor = cipher.decryptor()
+            decrypted = decryptor.update(encrypted_bytes) + decryptor.finalize()
+
+            # Try parsing as a Data protobuf
+            data_msg = mesh_pb2.Data()
+            data_msg.ParseFromString(decrypted)
+
+            # Validate: portnum should be in a reasonable range
+            if data_msg.portnum < 0 or data_msg.portnum > 511:
+                continue
+
+            # portnum 0 (UNKNOWN_APP) with empty payload is likely a bad decrypt
+            if data_msg.portnum == 0 and not data_msg.payload:
+                continue
+
+            return data_msg
+        except Exception:
+            continue
+
+    return None
+
+
+def decode_meshtastic_packet(
+    payload: bytes,
+    encryption_keys: list[bytes] | None = None,
+) -> dict | None:
     """
     Decode a Meshtastic protobuf packet, including inner payloads.
 
     Decodes the outer ServiceEnvelope/MeshPacket and then decodes the inner
     payload based on portnum (Position, User, Telemetry, RouteDiscovery, etc.)
     into dicts so downstream handlers receive structured data instead of raw bytes.
+
+    If the packet is encrypted and encryption_keys are provided, attempts
+    decryption with each key until one succeeds.
     """
     try:
         try:
@@ -36,14 +126,26 @@ def decode_meshtastic_packet(payload: bytes) -> dict | None:
                 "rxRssi": packet.rx_rssi,
             }
 
+            data_msg = None
+
             if packet.HasField("decoded"):
-                portnum = packet.decoded.portnum
+                data_msg = packet.decoded
+            elif packet.encrypted and encryption_keys:
+                data_msg = _decrypt_packet(
+                    packet.encrypted,
+                    packet.id,
+                    getattr(packet, "from"),
+                    encryption_keys,
+                )
+
+            if data_msg is not None:
+                portnum = data_msg.portnum
                 decoded["portnum"] = portnums_pb2.PortNum.Name(portnum)
-                raw_payload = packet.decoded.payload
-                if packet.decoded.reply_id:
-                    decoded["replyId"] = packet.decoded.reply_id
-                if packet.decoded.emoji:
-                    decoded["emoji"] = packet.decoded.emoji
+                raw_payload = data_msg.payload
+                if data_msg.reply_id:
+                    decoded["replyId"] = data_msg.reply_id
+                if data_msg.emoji:
+                    decoded["emoji"] = data_msg.emoji
 
                 # Decode inner payload based on portnum
                 decoded["payload"] = _decode_inner_payload(

--- a/backend/migrations/versions/add_psk_to_channels.py
+++ b/backend/migrations/versions/add_psk_to_channels.py
@@ -1,0 +1,22 @@
+"""Add psk column to channels table.
+
+Revision ID: i6j7k8l9m0n1
+Revises: h5i6j7k8l9m0
+Create Date: 2026-02-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "i6j7k8l9m0n1"
+down_revision = "h5i6j7k8l9m0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("channels", sa.Column("psk", sa.String(48), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("channels", "psk")

--- a/backend/tests/test_protobuf_decrypt.py
+++ b/backend/tests/test_protobuf_decrypt.py
@@ -1,0 +1,260 @@
+"""Tests for protobuf decryption in protobuf service."""
+
+import base64
+import struct
+
+import pytest
+
+from app.services.protobuf import (
+    MESHTASTIC_DEFAULT_KEY,
+    _decrypt_packet,
+    _expand_psk,
+    decode_meshtastic_packet,
+)
+
+
+class TestExpandPsk:
+    """Tests for _expand_psk() key expansion."""
+
+    def test_default_key_byte_1(self):
+        """Single byte 0x01 (AQ==) returns default key unchanged."""
+        key = _expand_psk("AQ==")
+        assert key == MESHTASTIC_DEFAULT_KEY
+        assert len(key) == 16
+
+    def test_single_byte_variant(self):
+        """Single byte 0x02 replaces last byte of default key."""
+        key = _expand_psk("Ag==")
+        assert key is not None
+        assert len(key) == 16
+        assert key[-1:] == b"\x02"
+        assert key[:-1] == MESHTASTIC_DEFAULT_KEY[:-1]
+
+    def test_full_16_byte_key(self):
+        """16-byte key is used as-is."""
+        raw = b"\x01" * 16
+        b64 = base64.b64encode(raw).decode()
+        key = _expand_psk(b64)
+        assert key == raw
+
+    def test_full_32_byte_key(self):
+        """32-byte key is used as-is (AES-256)."""
+        raw = b"\xab" * 32
+        b64 = base64.b64encode(raw).decode()
+        key = _expand_psk(b64)
+        assert key == raw
+
+    def test_empty_string_returns_none(self):
+        """Empty base64 (empty bytes) returns None."""
+        assert _expand_psk("") is None
+
+    def test_zero_byte_returns_none(self):
+        """Single zero byte returns None (no encryption)."""
+        assert _expand_psk("AA==") is None
+
+    def test_invalid_base64_returns_none(self):
+        """Invalid base64 input returns None."""
+        assert _expand_psk("not-valid-base64!!!") is None
+
+    def test_default_key_base64_roundtrip(self):
+        """The default key base64 string decodes correctly."""
+        key = _expand_psk("1PG7OiApB1nwvP+rz05pAQ==")
+        assert key == MESHTASTIC_DEFAULT_KEY
+
+
+class TestDecryptPacket:
+    """Tests for _decrypt_packet() AES-CTR decryption."""
+
+    def _encrypt(self, data_bytes: bytes, key: bytes, packet_id: int, from_node: int) -> bytes:
+        """Helper: encrypt bytes using AES-CTR with Meshtastic nonce format."""
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+        nonce = struct.pack("<QI", packet_id, from_node) + b"\x00" * 4
+        cipher = Cipher(algorithms.AES(key), modes.CTR(nonce))
+        encryptor = cipher.encryptor()
+        return encryptor.update(data_bytes) + encryptor.finalize()
+
+    def test_decrypt_with_correct_key(self):
+        """Decryption succeeds with the correct key."""
+        try:
+            from meshtastic import mesh_pb2, portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        # Build a Data message
+        data_msg = mesh_pb2.Data()
+        data_msg.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        data_msg.payload = b"Hello, mesh!"
+        serialized = data_msg.SerializeToString()
+
+        packet_id = 12345
+        from_node = 0xDEADBEEF
+        encrypted = self._encrypt(serialized, MESHTASTIC_DEFAULT_KEY, packet_id, from_node)
+
+        result = _decrypt_packet(encrypted, packet_id, from_node, [MESHTASTIC_DEFAULT_KEY])
+        assert result is not None
+        assert result.portnum == portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        assert result.payload == b"Hello, mesh!"
+
+    def test_decrypt_with_wrong_key_returns_none(self):
+        """Decryption with wrong key returns None."""
+        try:
+            from meshtastic import mesh_pb2, portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        data_msg = mesh_pb2.Data()
+        data_msg.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        data_msg.payload = b"Secret"
+        serialized = data_msg.SerializeToString()
+
+        packet_id = 99999
+        from_node = 0x12345678
+        encrypted = self._encrypt(serialized, MESHTASTIC_DEFAULT_KEY, packet_id, from_node)
+
+        wrong_key = b"\xff" * 16
+        result = _decrypt_packet(encrypted, packet_id, from_node, [wrong_key])
+        assert result is None
+
+    def test_decrypt_tries_multiple_keys(self):
+        """Decryption tries each key and succeeds on the matching one."""
+        try:
+            from meshtastic import mesh_pb2, portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        data_msg = mesh_pb2.Data()
+        data_msg.portnum = portnums_pb2.PortNum.POSITION_APP
+        data_msg.payload = b"\x08\x01"
+        serialized = data_msg.SerializeToString()
+
+        packet_id = 55555
+        from_node = 0xAABBCCDD
+        real_key = b"\x42" * 16
+        encrypted = self._encrypt(serialized, real_key, packet_id, from_node)
+
+        wrong_key = b"\x00" * 16
+        result = _decrypt_packet(encrypted, packet_id, from_node, [wrong_key, real_key])
+        assert result is not None
+        assert result.portnum == portnums_pb2.PortNum.POSITION_APP
+
+    def test_empty_keys_returns_none(self):
+        """Empty key list returns None."""
+        result = _decrypt_packet(b"\x00" * 20, 1, 1, [])
+        assert result is None
+
+
+class TestDecryptIntegration:
+    """Integration tests for decode_meshtastic_packet with encryption."""
+
+    def _build_encrypted_envelope(
+        self, key: bytes, portnum: int, payload: bytes, packet_id: int = 1000, from_node: int = 42
+    ) -> bytes:
+        """Build a ServiceEnvelope with an encrypted MeshPacket."""
+        try:
+            from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+            from meshtastic import mesh_pb2, mqtt_pb2
+        except ImportError:
+            pytest.skip("meshtastic or cryptography not available")
+
+        # Build the inner Data message
+        data_msg = mesh_pb2.Data()
+        data_msg.portnum = portnum
+        data_msg.payload = payload
+        data_serialized = data_msg.SerializeToString()
+
+        # Encrypt it
+        nonce = struct.pack("<QI", packet_id, from_node) + b"\x00" * 4
+        cipher = Cipher(algorithms.AES(key), modes.CTR(nonce))
+        encryptor = cipher.encryptor()
+        encrypted = encryptor.update(data_serialized) + encryptor.finalize()
+
+        # Build the MeshPacket with encrypted field
+        packet = mesh_pb2.MeshPacket()
+        setattr(packet, "from", from_node)
+        packet.to = 0xFFFFFFFF
+        packet.id = packet_id
+        packet.encrypted = encrypted
+
+        # Wrap in ServiceEnvelope
+        envelope = mqtt_pb2.ServiceEnvelope()
+        envelope.packet.CopyFrom(packet)
+        return envelope.SerializeToString()
+
+    def test_encrypted_text_message_decoded(self):
+        """An encrypted TEXT_MESSAGE_APP is decrypted and decoded."""
+        try:
+            from meshtastic import portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        envelope_bytes = self._build_encrypted_envelope(
+            key=MESHTASTIC_DEFAULT_KEY,
+            portnum=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+            payload=b"Hello from encrypted!",
+        )
+
+        result = decode_meshtastic_packet(envelope_bytes, encryption_keys=[MESHTASTIC_DEFAULT_KEY])
+        assert result is not None
+        assert result.get("portnum") == "TEXT_MESSAGE_APP"
+        assert result.get("text") == "Hello from encrypted!"
+
+    def test_encrypted_position_decoded(self):
+        """An encrypted POSITION_APP is decrypted and the inner protobuf decoded."""
+        try:
+            from meshtastic import mesh_pb2, portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        pos = mesh_pb2.Position()
+        pos.latitude_i = 259560000
+        pos.longitude_i = -801810000
+        pos_bytes = pos.SerializeToString()
+
+        envelope_bytes = self._build_encrypted_envelope(
+            key=MESHTASTIC_DEFAULT_KEY,
+            portnum=portnums_pb2.PortNum.POSITION_APP,
+            payload=pos_bytes,
+        )
+
+        result = decode_meshtastic_packet(envelope_bytes, encryption_keys=[MESHTASTIC_DEFAULT_KEY])
+        assert result is not None
+        assert result.get("portnum") == "POSITION_APP"
+        payload = result.get("payload")
+        assert isinstance(payload, dict)
+        assert "latitudeI" in payload
+
+    def test_no_keys_skips_encrypted(self):
+        """Without encryption keys, encrypted packets return no portnum."""
+        try:
+            from meshtastic import portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        envelope_bytes = self._build_encrypted_envelope(
+            key=MESHTASTIC_DEFAULT_KEY,
+            portnum=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+            payload=b"Secret",
+        )
+
+        result = decode_meshtastic_packet(envelope_bytes, encryption_keys=None)
+        assert result is not None
+        assert "portnum" not in result  # encrypted, but no keys to decrypt
+
+    def test_wrong_keys_skips_encrypted(self):
+        """With wrong encryption keys, encrypted packets return no portnum."""
+        try:
+            from meshtastic import portnums_pb2
+        except ImportError:
+            pytest.skip("meshtastic library not available")
+
+        envelope_bytes = self._build_encrypted_envelope(
+            key=MESHTASTIC_DEFAULT_KEY,
+            portnum=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+            payload=b"Secret",
+        )
+
+        wrong_key = b"\xff" * 16
+        result = decode_meshtastic_packet(envelope_bytes, encryption_keys=[wrong_key])
+        assert result is not None
+        assert "portnum" not in result


### PR DESCRIPTION
## Summary

- **Decrypt encrypted MQTT packets** — ~94% of MQTT traffic arrives encrypted. This adds AES-128/256-CTR decryption using channel PSKs, unlocking position, telemetry, traceroute, and text message data across all of Florida (not just South Florida).
- **Store channel PSKs from MeshMonitor** — Adds a `psk` column to the Channel model and stores base64-encoded PSKs from the MeshMonitor API during collection.
- **Cache encryption keys in MQTT collector** — Queries all channel PSKs, expands them per Meshtastic protocol (single-byte → default key variant, 16/32 byte → as-is), deduplicates, and caches with 5-minute TTL. Always includes the default "LongFast" key as fallback.

### Files changed
| File | Change |
|------|--------|
| `backend/app/models/channel.py` | Add `psk` column (String(48), nullable) |
| `backend/migrations/versions/add_psk_to_channels.py` | Alembic migration for `psk` column |
| `backend/app/collectors/meshmonitor.py` | Store `psk` from MeshMonitor API |
| `backend/app/services/protobuf.py` | Add `_expand_psk()`, `_decrypt_packet()`, update `decode_meshtastic_packet()` with encryption support |
| `backend/app/collectors/mqtt.py` | Add `_get_encryption_keys()` with caching, pass keys to decoder |
| `backend/tests/test_protobuf_decrypt.py` | 16 new tests (PSK expansion, decryption, integration) |

### Results from dev deployment
- 419 MQTT traceroutes collected (193 with complete `route_back`)
- 254 new route segments from MQTT not previously available from MeshMonitor
- Geographic coverage expanded from South Florida to all of Florida (lat 24.97°–30.52°)
- 335 MQTT nodes created, 265 with GPS positions

## Test plan
- [x] Backend tests pass (125 passed, 24 skipped)
- [x] Frontend tests pass (95 passed)
- [x] Migration applies cleanly
- [x] Dev deployment verified with live MQTT data
- [ ] Verify traceroute segments render on map across Florida
- [ ] Verify new node positions appear on map

🤖 Generated with [Claude Code](https://claude.com/claude-code)