### PR TITLE
chore: Release v0.6.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.5.2"
+version = "0.6.0"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/configuration/configurator.md
+++ b/docs/configuration/configurator.md
@@ -94,9 +94,9 @@ Use this interactive configurator to generate a customized `docker-compose.yml` 
   <label for="version">MeshManager Version</label>
   <select id="version" v-model="config.version">
     <option value="latest">latest (recommended)</option>
+    <option value="0.6.0">0.6.0</option>
+    <option value="0.5.2">0.5.2</option>
     <option value="0.5.0">0.5.0</option>
-    <option value="0.4.0">0.4.0</option>
-    <option value="0.3.1">0.3.1</option>
   </select>
 </div>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump to 0.6.0 for release.

## Changes since v0.5.2

### Features
- [#71](https://github.com/Yeraze/meshmanager/pull/71) - Add `DISABLE_LOCAL_AUTH` and enhance OIDC configuration
- [#69](https://github.com/Yeraze/meshmanager/pull/69) - Add role-based user management
- [#68](https://github.com/Yeraze/meshmanager/pull/68) - Decrypt encrypted MQTT packets using channel PSKs
- [#65](https://github.com/Yeraze/meshmanager/pull/65) - Resolve MQTT traceroute node names to numbers
- [#64](https://github.com/Yeraze/meshmanager/pull/64) - Add MQTT traceroute handler
- [#63](https://github.com/Yeraze/meshmanager/pull/63) - Adopt MeshMonitor-style map markers and node popups
- [#60](https://github.com/Yeraze/meshmanager/pull/60) - Add reply indicators and tapback/reaction rendering
- [#59](https://github.com/Yeraze/meshmanager/pull/59) - Source filter buttons and channel name grouping

### Bug Fixes
- [#70](https://github.com/Yeraze/meshmanager/pull/70) - Include MQTT data in coverage maps, position history, and utilization
- [#67](https://github.com/Yeraze/meshmanager/pull/67) - Decode inner protobuf payloads in MQTT collector
- [#66](https://github.com/Yeraze/meshmanager/pull/66) - Filter route segments by enabled sources and fix message timestamp ordering
- [#62](https://github.com/Yeraze/meshmanager/pull/62) - Remove backend node deduplication to support multi-source filtering
- [#61](https://github.com/Yeraze/meshmanager/pull/61) - Use timezone-aware UTC datetimes to prevent MQTT timestamp offset
- [#58](https://github.com/Yeraze/meshmanager/pull/58) - Resolve MQTT collector connection failure and message processing
- [#55](https://github.com/Yeraze/meshmanager/pull/55) - Add deduplication for traceroute collection
- [#53](https://github.com/Yeraze/meshmanager/pull/53) - Handle flat position fields in v1 API node response

### Issues Resolved
- [#57](https://github.com/Yeraze/meshmanager/issues/57) - Analysis: message utilization hides traceroute

## Test plan

- [x] Backend tests pass (179 passed)
- [x] Frontend tests pass (95 passed)
- [x] Version bumped in `backend/pyproject.toml`, `frontend/package.json`, `frontend/package-lock.json`
- [x] Docker configurator version dropdown updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)