### PR TITLE
fix: Convert emoji codepoints to characters for tapback rendering

### DIFF
--- a/backend/app/collectors/meshmonitor.py
+++ b/backend/app/collectors/meshmonitor.py
@@ -880,12 +880,14 @@ class MeshMonitorCollector(BaseCollector):
         if value is None:
             return None
         if isinstance(value, int):
-            return chr(value) if 0 < value <= 0x10FFFF else None
+            # Filter control characters (< 0x20) — e.g. Meshtastic sends 0x01 as a
+            # "reaction present" flag, not a real emoji codepoint
+            return chr(value) if 0x20 <= value <= 0x10FFFF else None
         if isinstance(value, str) and value:
             # If it's a numeric string (e.g. "128077"), convert to emoji
             try:
                 codepoint = int(value)
-                return chr(codepoint) if 0 < codepoint <= 0x10FFFF else None
+                return chr(codepoint) if 0x20 <= codepoint <= 0x10FFFF else None
             except (ValueError, OverflowError):
                 pass
             return value

--- a/backend/app/services/protobuf.py
+++ b/backend/app/services/protobuf.py
@@ -145,11 +145,13 @@ def decode_meshtastic_packet(
                 if data_msg.reply_id:
                     decoded["replyId"] = data_msg.reply_id
                 if data_msg.emoji:
-                    # Protobuf emoji field is a fixed32 Unicode codepoint
-                    try:
-                        decoded["emoji"] = chr(data_msg.emoji)
-                    except (ValueError, OverflowError):
-                        decoded["emoji"] = data_msg.emoji
+                    # Protobuf emoji field is a fixed32 Unicode codepoint.
+                    # Values < 0x20 are control chars (e.g. 0x01 = "reaction present" flag)
+                    if data_msg.emoji >= 0x20:
+                        try:
+                            decoded["emoji"] = chr(data_msg.emoji)
+                        except (ValueError, OverflowError):
+                            pass
 
                 # Decode inner payload based on portnum
                 decoded["payload"] = _decode_inner_payload(

--- a/backend/tests/test_emoji.py
+++ b/backend/tests/test_emoji.py
@@ -46,3 +46,16 @@ class TestDecodeEmoji:
     def test_empty_string_returns_none(self):
         c = self._make_collector()
         assert c._decode_emoji("") is None
+
+    def test_control_char_0x01_returns_none(self):
+        """Meshtastic sends 0x01 as a 'reaction present' flag, not a real emoji."""
+        c = self._make_collector()
+        assert c._decode_emoji(1) is None
+
+    def test_control_char_string_0x01_returns_none(self):
+        c = self._make_collector()
+        assert c._decode_emoji("1") is None
+
+    def test_numeric_string_below_0x20_returns_none(self):
+        c = self._make_collector()
+        assert c._decode_emoji("15") is None


### PR DESCRIPTION
## Summary
- Meshtastic's protobuf `emoji` field is a `fixed32` Unicode codepoint (e.g. `128077` for 👍), but was being stored as the raw integer or string representation instead of the actual emoji character
- Fixed `protobuf.py` to convert codepoints via `chr()` when decoding MQTT packets
- Added `_decode_emoji()` helper to `MeshMonitorCollector` to handle int, numeric string, and emoji string inputs
- Added unit tests for all emoji decoding paths

## Test plan
- [x] Backend tests pass (187 passed)
- [x] Frontend tests pass (95 passed)
- [x] Lint clean (no new issues)
- [ ] Deploy and verify emoji tapbacks render correctly in Communications tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)