### PR TITLE
chore: Bump version to 0.6.1

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.6.0"
+version = "0.6.1"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/configuration/configurator.md
+++ b/docs/configuration/configurator.md
@@ -94,6 +94,7 @@ Use this interactive configurator to generate a customized `docker-compose.yml` 
   <label for="version">MeshManager Version</label>
   <select id="version" v-model="config.version">
     <option value="latest">latest (recommended)</option>
+    <option value="0.6.1">0.6.1</option>
     <option value="0.6.0">0.6.0</option>
     <option value="0.5.2">0.5.2</option>
     <option value="0.5.0">0.5.0</option>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to 0.6.1 across backend, frontend, and docs configurator

## v0.6.1 Hotfix Release Notes

### Bug Fixes
- **Auto-run Alembic migrations on startup** — Replaces `Base.metadata.create_all` with `alembic upgrade head` so schema changes are applied automatically on Docker image upgrades. Detects pre-Alembic databases (v0.5.2 or earlier) and stamps at baseline before upgrading. ([#75](https://github.com/Yeraze/meshmanager/pull/75), fixes [#73](https://github.com/Yeraze/meshmanager/issues/73))
- **Convert emoji codepoints to characters for tapback rendering** ([#74](https://github.com/Yeraze/meshmanager/pull/74))

### Issues Resolved
- [#73](https://github.com/Yeraze/meshmanager/issues/73) — Upgrading Docker image from v0.5.2 to v0.6.0 breaks instance

## Test plan

- [x] `pytest -x -q` — 195 passed, 30 skipped
- [x] Frontend tests — 95 passed
- [x] `ruff check` on changed files — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)