### PR TITLE
fix: Make post-v0.5.2 migrations idempotent for crash recovery

### DIFF
--- a/backend/migrations/versions/add_index_on_nodes_long_name.py
+++ b/backend/migrations/versions/add_index_on_nodes_long_name.py
@@ -14,7 +14,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_index(op.f("ix_nodes_long_name"), "nodes", ["long_name"], unique=False)
+    # IF NOT EXISTS for crash-recovery idempotency
+    op.execute("CREATE INDEX IF NOT EXISTS ix_nodes_long_name ON nodes (long_name)")
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/add_meshtastic_id_to_messages.py
+++ b/backend/migrations/versions/add_meshtastic_id_to_messages.py
@@ -21,9 +21,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Add the column
-    op.add_column("messages", sa.Column("meshtastic_id", sa.BigInteger(), nullable=True))
-    op.create_index("ix_messages_meshtastic_id", "messages", ["meshtastic_id"])
+    # Add the column (IF NOT EXISTS for crash-recovery idempotency)
+    op.execute("ALTER TABLE messages ADD COLUMN IF NOT EXISTS meshtastic_id BIGINT")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_messages_meshtastic_id ON messages (meshtastic_id)"
+    )
 
     # Backfill from existing packet_id data:
     # - MeshMonitor format: '{from_node}_{raw_id}' -> extract part after last '_'

--- a/backend/migrations/versions/add_psk_to_channels.py
+++ b/backend/migrations/versions/add_psk_to_channels.py
@@ -15,7 +15,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("channels", sa.Column("psk", sa.String(48), nullable=True))
+    # IF NOT EXISTS for crash-recovery idempotency
+    op.execute("ALTER TABLE channels ADD COLUMN IF NOT EXISTS psk VARCHAR(48)")
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/add_role_to_users.py
+++ b/backend/migrations/versions/add_role_to_users.py
@@ -15,9 +15,12 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("users", sa.Column("role", sa.String(20), nullable=False, server_default="viewer"))
+    # IF NOT EXISTS for crash-recovery idempotency
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(20) NOT NULL DEFAULT 'viewer'"
+    )
     op.execute("UPDATE users SET role = 'admin' WHERE is_admin = true")
-    op.drop_column("users", "is_admin")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS is_admin")
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/add_traceroute_unique_constraint.py
+++ b/backend/migrations/versions/add_traceroute_unique_constraint.py
@@ -37,13 +37,11 @@ def upgrade() -> None:
         )
     """)
 
-    # Now add the unique constraint
-    op.create_index(
-        "idx_traceroutes_unique",
-        "traceroutes",
-        ["source_id", "from_node_num", "to_node_num", "received_at"],
-        unique=True,
-    )
+    # Now add the unique constraint (IF NOT EXISTS for crash-recovery idempotency)
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_traceroutes_unique
+        ON traceroutes (source_id, from_node_num, to_node_num, received_at)
+    """)
 
 
 def downgrade() -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.6.2"
+version = "0.6.3"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/configuration/configurator.md
+++ b/docs/configuration/configurator.md
@@ -94,6 +94,7 @@ Use this interactive configurator to generate a customized `docker-compose.yml` 
   <label for="version">MeshManager Version</label>
   <select id="version" v-model="config.version">
     <option value="latest">latest (recommended)</option>
+    <option value="0.6.3">0.6.3</option>
     <option value="0.6.2">0.6.2</option>
     <option value="0.6.1">0.6.1</option>
     <option value="0.6.0">0.6.0</option>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Makes all 7 post-v0.5.2 migrations idempotent using `IF NOT EXISTS` / `IF EXISTS` so they safely re-run after a partial application
- Bumps version to 0.6.3

## Problem

The v0.6.1 crash loop (fixed in v0.6.2 by moving migrations to `entrypoint.sh`) partially applied migration `e2f3g4h5i6j7` — the `DELETE` and `CREATE UNIQUE INDEX` executed, but the container was killed before alembic committed the version to `alembic_version`. On the next attempt, `CREATE UNIQUE INDEX idx_traceroutes_unique` fails with `DuplicateTableError` because the index already exists.

## Solution

Replace `op.create_index`, `op.add_column`, and `op.create_check_constraint` with raw SQL equivalents using `IF NOT EXISTS` / `IF EXISTS` across all affected migrations:

| Migration | Changes |
|-----------|---------|
| `e2f3g4h5i6j7` (traceroute constraint) | `CREATE UNIQUE INDEX IF NOT EXISTS` |
| `g4h5i6j7k8l9` (meshtastic_id) | `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS` |
| `h5i6j7k8l9m0` (nodes long_name index) | `CREATE INDEX IF NOT EXISTS` |
| `i6j7k8l9m0n1` (psk to channels) | `ADD COLUMN IF NOT EXISTS` |
| `j7k8l9m0n1o2` (role to users) | `ADD COLUMN IF NOT EXISTS`, `DROP COLUMN IF EXISTS` |
| `k8l9m0n1o2p3` (totp & permissions) | `ADD COLUMN IF NOT EXISTS`, `DO $$ ... IF NOT EXISTS` for check constraint |

Fixes #73

## Test plan

- [x] `pytest -x -q` — 194 passed, 30 skipped
- [ ] Deploy to instance stuck in crash loop — should recover cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)