### PR TITLE
feat: Add relay_node to message sources

### DIFF
--- a/backend/app/collectors/meshmonitor.py
+++ b/backend/app/collectors/meshmonitor.py
@@ -586,6 +586,7 @@ class MeshMonitorCollector(BaseCollector):
             "hop_start": msg_data.get("hopStart"),
             "rx_snr": msg_data.get("rxSnr"),
             "rx_rssi": msg_data.get("rxRssi"),
+            "relay_node": msg_data.get("relayNode"),
             "rx_time": rx_time,
             "received_at": received_at,
         }

--- a/backend/app/collectors/mqtt.py
+++ b/backend/app/collectors/mqtt.py
@@ -308,6 +308,7 @@ class MqttCollector(BaseCollector):
             rx_time=rx_time,
             rx_snr=data.get("rxSnr"),
             rx_rssi=data.get("rxRssi"),
+            relay_node=data.get("relayNode"),
         )
         db.add(message)
         logger.debug(f"Received text message from {from_node}")

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -50,6 +50,7 @@ class Message(Base):
     rx_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     rx_snr: Mapped[float | None] = mapped_column(Integer)  # Stored as int, represents dB * 4
     rx_rssi: Mapped[int | None] = mapped_column(Integer)
+    relay_node: Mapped[int | None] = mapped_column(BigInteger)
 
     # Timestamp
     received_at: Mapped[datetime] = mapped_column(

--- a/backend/app/services/protobuf.py
+++ b/backend/app/services/protobuf.py
@@ -124,6 +124,7 @@ def decode_meshtastic_packet(
                 "rxTime": packet.rx_time or None,
                 "rxSnr": packet.rx_snr,
                 "rxRssi": packet.rx_rssi,
+                "relayNode": packet.relay_node,
             }
 
             data_msg = None

--- a/backend/migrations/versions/add_relay_node_to_messages.py
+++ b/backend/migrations/versions/add_relay_node_to_messages.py
@@ -1,0 +1,21 @@
+"""Add relay_node column to messages table.
+
+Revision ID: m0n1o2p3q4r5
+Revises: l9m0n1o2p3q4
+Create Date: 2026-02-10
+"""
+
+from alembic import op
+
+revision = "m0n1o2p3q4r5"
+down_revision = "l9m0n1o2p3q4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE messages ADD COLUMN IF NOT EXISTS relay_node BIGINT")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE messages DROP COLUMN IF EXISTS relay_node")

--- a/frontend/src/components/Communication/CommunicationPage.tsx
+++ b/frontend/src/components/Communication/CommunicationPage.tsx
@@ -7,7 +7,12 @@ import MessageDetailModal from './MessageDetailModal'
 
 export default function CommunicationPage() {
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null)
-  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null)
+  const [selectedMessage, setSelectedMessage] = useState<{
+    packetId: string
+    senderName: string
+    text: string | null
+    timestamp: string
+  } | null>(null)
   const [disabledSources, setDisabledSources] = useState<Set<string>>(new Set())
 
   const {
@@ -37,12 +42,12 @@ export default function CommunicationPage() {
     })
   }, [])
 
-  const handleMessageClick = (packetId: string) => {
-    setSelectedMessageId(packetId)
+  const handleMessageClick = (info: { packetId: string; senderName: string; text: string | null; timestamp: string }) => {
+    setSelectedMessage(info)
   }
 
   const handleCloseModal = () => {
-    setSelectedMessageId(null)
+    setSelectedMessage(null)
   }
 
   // Get the selected channel info
@@ -193,8 +198,14 @@ export default function CommunicationPage() {
       </div>
 
       {/* Message Detail Modal */}
-      {selectedMessageId && (
-        <MessageDetailModal packetId={selectedMessageId} onClose={handleCloseModal} />
+      {selectedMessage && (
+        <MessageDetailModal
+          packetId={selectedMessage.packetId}
+          senderName={selectedMessage.senderName}
+          messageText={selectedMessage.text}
+          timestamp={selectedMessage.timestamp}
+          onClose={handleCloseModal}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/Communication/MessageDetailModal.module.css
+++ b/frontend/src/components/Communication/MessageDetailModal.module.css
@@ -54,6 +54,37 @@
   color: var(--color-text, #cdd6f4);
 }
 
+.messageSummary {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border, #313244);
+  background: var(--color-surface-elevated, rgba(255, 255, 255, 0.03));
+}
+
+.messageMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.messageSender {
+  font-weight: 600;
+  color: var(--color-primary, #89b4fa);
+  font-size: 0.9rem;
+}
+
+.messageTimestamp {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.messageText {
+  font-size: 0.9rem;
+  color: var(--color-text, #cdd6f4);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
 .content {
   padding: 1.5rem;
   overflow-y: auto;

--- a/frontend/src/components/Communication/MessageList.tsx
+++ b/frontend/src/components/Communication/MessageList.tsx
@@ -4,7 +4,7 @@ import { fetchMessages, type MessageResponse } from '../../services/api'
 
 interface MessageListProps {
   channelKey: string
-  onMessageClick: (packetId: string) => void
+  onMessageClick: (info: { packetId: string; senderName: string; text: string | null; timestamp: string }) => void
   sourceNames?: string[]
 }
 
@@ -283,7 +283,12 @@ export default function MessageList({ channelKey, onMessageClick, sourceNames }:
             return (
               <button
                 key={msg.packet_id}
-                onClick={() => onMessageClick(msg.packet_id)}
+                onClick={() => onMessageClick({
+                  packetId: msg.packet_id,
+                  senderName: getNodeDisplayName(msg),
+                  text: msg.text,
+                  timestamp: getMessageTimestamp(msg),
+                })}
                 style={{
                   width: '100%',
                   padding: '0.75rem',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -649,6 +649,8 @@ export interface MessageSourceDetail {
   hop_limit: number | null
   hop_start: number | null
   hop_count: number | null
+  relay_node: number | null
+  relay_node_name: string | null
   rx_time: string | null
   received_at: string
 }


### PR DESCRIPTION
## Summary
- Capture the `relay_node` field from Meshtastic `MeshPacket` protobuf during ingestion and store it in the `messages` table
- Resolve relay node number to a display name via the `nodes` table in the sources API
- Display a "Relay" column in the message detail modal's per-source reception table
- Works for both MQTT (extracted from raw protobuf) and MeshMonitor (returned as `relayNode` in API response)

## Changes
- **Migration**: Idempotent `ADD COLUMN IF NOT EXISTS relay_node BIGINT` on `messages`
- **Model**: `relay_node` field on `Message`
- **Protobuf decoder**: Extract `relay_node` from `MeshPacket`
- **MQTT collector**: Pass `relay_node` to `Message()` constructor
- **MeshMonitor collector**: Pass `relayNode` from API response to insert
- **Messages API**: Add `relay_node` and `relay_node_name` to `MessageSourceDetail`, with `LEFT JOIN` on `nodes` for name resolution
- **Frontend**: Add `relay_node`/`relay_node_name` to `MessageSourceDetail` interface, add "Relay" column to reception table with hex fallback formatting

## Test plan
- [x] `pytest -x -q` — 270 passed
- [x] `npm test -- --run` — 95 passed
- [x] `ruff check` — clean on changed files
- [ ] Deploy with `docker compose -f docker-compose.dev.yml up -d --build` and verify relay column in message detail modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)