### PR TITLE
fix: Match correct constraint name for duplicate message detection

### DIFF
--- a/backend/app/collectors/mqtt.py
+++ b/backend/app/collectors/mqtt.py
@@ -183,7 +183,7 @@ class MqttCollector(BaseCollector):
                 await db.commit()
         except IntegrityError as e:
             err = str(e)
-            if "ix_messages_source_packet" in err:
+            if "idx_messages_source_packet" in err:
                 logger.debug("Duplicate message ignored (likely overlapping topics)")
             elif "idx_traceroutes_unique" in err:
                 logger.debug("Duplicate traceroute ignored")


### PR DESCRIPTION
## Summary
- The MQTT collector's `IntegrityError` handler checked for `ix_messages_source_packet` but the actual unique constraint is named `idx_messages_source_packet`
- This caused normal duplicate MQTT messages to be logged as unexpected errors (`ERROR - Unexpected integrity error`) instead of being silently ignored at `DEBUG` level

## Test plan
- [x] `pytest -x -q` — 270 passed
- [ ] Deploy and confirm duplicate message log lines drop from ERROR to DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)