### PR TITLE
chore: Bump version to 0.6.6 and add user management docs

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.6.5"
+version = "0.6.6"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,6 +49,7 @@ export default defineConfig({
             { text: 'Environment Variables', link: '/configuration/environment' },
             { text: 'Data Sources', link: '/configuration/sources' },
             { text: 'SSO (OpenID Connect)', link: '/configuration/sso' },
+            { text: 'User Management', link: '/configuration/users' },
             { text: 'Solar Integration', link: '/configuration/solar' },
             { text: 'Notifications', link: '/configuration/notifications' },
           ]

--- a/docs/configuration/configurator.md
+++ b/docs/configuration/configurator.md
@@ -94,6 +94,7 @@ Use this interactive configurator to generate a customized `docker-compose.yml` 
   <label for="version">MeshManager Version</label>
   <select id="version" v-model="config.version">
     <option value="latest">latest (recommended)</option>
+    <option value="0.6.6">0.6.6</option>
     <option value="0.6.5">0.6.5</option>
     <option value="0.6.4">0.6.4</option>
     <option value="0.6.3">0.6.3</option>

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -29,6 +29,10 @@ Authentication is always enabled. The first user to register becomes an admin.
 
 For SSO configuration details, see the [SSO (OpenID Connect)](/configuration/sso) guide.
 
+::: tip
+Anonymous user permissions and per-user tab permissions are configured through the web UI at **Settings > Users**, not via environment variables. See the [User Management](/configuration/users) guide for details.
+:::
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OIDC_ISSUER` | | OIDC provider issuer URL |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -45,6 +45,10 @@ Configure automated alerts:
 Configure how users log in:
 - [SSO (OpenID Connect)](/configuration/sso) - OIDC setup with Authentik, Keycloak, Auth0, etc.
 
+### User Management
+
+- [User Management](/configuration/users) - Roles, permissions, and anonymous access
+
 ### Environment Variables
 
 System-level configuration:

--- a/docs/configuration/sso.md
+++ b/docs/configuration/sso.md
@@ -191,7 +191,7 @@ The redirect URI configured in your OIDC provider must exactly match the `OIDC_R
 
 ### SSO login succeeds but user has no permissions
 
-By default, SSO users are created with the **user** role. An admin can adjust roles and permissions in the **Admin > Users** panel.
+By default, SSO users are created with the **user** role. An admin can adjust roles and permissions on the [Settings > Users](/configuration/users) page.
 
 ### "Auto-creation of OIDC users is disabled" error
 

--- a/docs/configuration/users.md
+++ b/docs/configuration/users.md
@@ -1,0 +1,85 @@
+# User Management & Permissions
+
+MeshManager includes a built-in authentication and authorization system. The first user to register automatically becomes an admin. All users and permissions are managed through the **Settings > Users** page.
+
+## User Roles
+
+MeshManager has two roles:
+
+| Role | Description |
+|------|-------------|
+| **Admin** | Full access to all features. Can manage users, data sources, and system settings. Bypasses all tab-based permissions. |
+| **User** | Access governed by per-tab permissions. Cannot access the Settings page (user management, sources, etc.) unless explicitly granted. |
+
+## Tab-Based Permissions
+
+Each user (except admins, who always have full access) has read and write permissions for each of the six application tabs:
+
+| Tab | Controls |
+|-----|----------|
+| **Map** | Interactive map with node positions and heatmaps |
+| **Nodes** | Node list, filtering, and node detail views |
+| **Graphs** | Telemetry charts (battery, channel utilization, signal quality, etc.) |
+| **Analysis** | Traceroute visualization, network topology, and signal analysis |
+| **Communication** | Messages and communication data |
+| **Settings** | User management, data sources, solar config, and notifications |
+
+Each tab has two permission flags:
+
+- **Read** — Can view the tab and its data
+- **Write** — Can make changes (e.g., edit node names, trigger actions)
+
+When a tab's read permission is disabled, the tab is hidden from the user's navigation.
+
+## Managing Users
+
+Admins can manage users at **Settings > Users**:
+
+- **Create** — Add new users with a username, password, and optional email/display name. Set their role and permissions.
+- **Edit** — Change a user's role, permissions, active status, or reset their password.
+- **Delete** — Remove a user account.
+
+### Two-Factor Authentication (TOTP)
+
+Users can enable TOTP-based two-factor authentication from their profile. When enabled, a six-digit code from an authenticator app (Google Authenticator, Authy, etc.) is required at each login.
+
+## Anonymous User (Public Access)
+
+MeshManager includes a built-in **anonymous user** that controls what unauthenticated visitors can see. This allows you to make parts of your dashboard publicly accessible without requiring login.
+
+Key characteristics:
+
+- **Always present** — The anonymous user appears at the top of the Users list with an "Anonymous" badge. It cannot be deleted.
+- **Permissions only** — Only the anonymous user's tab permissions can be edited. Username, password, and role cannot be changed.
+- **Default behavior** — Read access is enabled for all tabs except Settings, with write access disabled everywhere. This preserves open, read-only behavior for existing deployments.
+- **Restricting access** — To hide a tab from unauthenticated visitors, disable its read permission on the anonymous user.
+- **Login prompt** — When an unauthenticated visitor tries to access a tab the anonymous user cannot read, they receive a 401 response which triggers the login modal.
+
+## Default Permissions
+
+| Tab | Admin | Regular User | Anonymous |
+|-----|-------|-------------|-----------|
+| Map | read + write | read | read |
+| Nodes | read + write | read | read |
+| Graphs | read + write | read | read |
+| Analysis | read + write | read | read |
+| Communication | read + write | read | read |
+| Settings | read + write | read | no access |
+
+::: tip
+Admin users bypass the permissions system entirely — they always have full read and write access regardless of what their permissions dict contains.
+:::
+
+## Examples
+
+### Make the dashboard fully private
+
+Set all anonymous user tab permissions to no read access. Every visitor will be prompted to log in.
+
+### Allow public map but require login for everything else
+
+On the anonymous user, enable read for the **Map** tab only. Disable read on all other tabs.
+
+### Create a read-only monitoring user
+
+Create a regular user with read enabled on all tabs and write disabled everywhere. This user can view all data but cannot make any changes.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -52,6 +52,13 @@ Automated reports delivered on schedule:
 - Node relationship mapping
 - Signal quality analysis
 
+### User Management & Permissions
+
+- Role-based access control (admin and user roles)
+- Per-tab read/write permissions
+- Configurable anonymous access for unauthenticated visitors
+- Two-factor authentication (TOTP)
+
 ## Feature Pages
 
 - [Dashboard](/features/dashboard) - Main overview page
@@ -59,3 +66,4 @@ Automated reports delivered on schedule:
 - [Solar Monitoring](/features/solar-monitoring) - Solar-specific features
 - [Notifications](/features/notifications) - Alert configuration
 - [Multi-Source Support](/features/multi-source) - Working with multiple data sources
+- [User Management](/configuration/users) - Roles, permissions, and anonymous access

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version from 0.6.5 to 0.6.6 across backend, frontend, package-lock, and docs configurator
- Add new `docs/configuration/users.md` covering user roles, tab-based permissions, anonymous user, and default permission tables
- Update sidebar nav, configuration index, features index, SSO docs, and environment docs with cross-links to the new page

## Test plan
- [x] Backend tests pass (`pytest -x -q` — 286 passed)
- [x] Frontend tests pass (`npm test -- --run` — 95 passed)
- [x] Grep confirms no stale `0.6.5` references outside the version history dropdown
- [ ] Verify docs render correctly on VitePress (`npm run docs:dev`)
- [ ] Confirm all cross-links resolve (sidebar, index pages, SSO troubleshooting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)