### PR TITLE
feat: Add version number and GitHub link to sidebar

### DIFF
--- a/frontend/src/components/Layout/NavSidebar.tsx
+++ b/frontend/src/components/Layout/NavSidebar.tsx
@@ -58,6 +58,21 @@ export default function NavSidebar({ currentPage, onPageChange }: NavSidebarProp
           </button>
         ))}
       </div>
+
+      <div className="nav-footer">
+        {!isCollapsed && <span className="nav-version">v{__APP_VERSION__}</span>}
+        <a
+          href="https://github.com/yeraze/meshmanager"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="nav-github"
+          title="GitHub"
+        >
+          <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+          </svg>
+        </a>
+      </div>
     </nav>
   )
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1255,6 +1255,36 @@ body {
   justify-content: center;
 }
 
+.nav-footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+}
+
+.nav-version {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.nav-github {
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  transition: color var(--transition-fast);
+}
+
+.nav-github:hover {
+  color: var(--color-primary);
+}
+
+.nav-sidebar.collapsed .nav-footer {
+  justify-content: center;
+  padding: var(--spacing-sm);
+}
+
 /* Page Content */
 .page-content {
   flex: 1;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string
+
 declare module 'leaflet/dist/images/marker-icon-2x.png' {
   const value: string
   export default value

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { readFileSync } from 'fs'
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Display the current app version (e.g. `v0.6.6`) at the bottom-left of the navigation sidebar
- Add a GitHub Octocat icon linking to the repo next to the version
- Version is injected at build time from `package.json` via Vite's `define` option
- Both elements adapt to the sidebar's collapsed/expanded state (version text hides when collapsed, icon stays)

## Test plan
- [x] Frontend tests pass (95 passed)
- [x] Production build succeeds
- [x] Visually verified on dev deployment — version and icon render correctly
- [ ] Verify collapsed sidebar shows only the GitHub icon
- [ ] Verify GitHub link opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)