### PR TITLE
fix: Add server_default declarations and migration for NOT NULL columns

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run linter
         run: ruff check app/
 
+      - name: Validate server defaults
+        run: python scripts/validate_server_defaults.py
+
   docker-build:
     name: Docker Build Test
     runs-on: ubuntu-latest

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -31,8 +31,8 @@ class Channel(Base):
     name: Mapped[str | None] = mapped_column(String(12))
     role: Mapped[str | None] = mapped_column(String(20))  # primary, secondary, disabled
 
-    uplink_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
-    downlink_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    uplink_enabled: Mapped[bool] = mapped_column(Boolean, default=False, server_default=text("false"))
+    downlink_enabled: Mapped[bool] = mapped_column(Boolean, default=False, server_default=text("false"))
     position_precision: Mapped[int | None] = mapped_column(Integer)
     psk: Mapped[str | None] = mapped_column(String(48))  # base64-encoded AES key
 

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -36,7 +36,7 @@ class Message(Base):
     )  # Raw Meshtastic packet ID
     from_node_num: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
     to_node_num: Mapped[int | None] = mapped_column(BigInteger)
-    channel: Mapped[int] = mapped_column(Integer, default=0)
+    channel: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
     text: Mapped[str | None] = mapped_column(Text)
 
     # Reply/reaction

--- a/backend/app/models/node.py
+++ b/backend/app/models/node.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -61,7 +62,7 @@ class Node(Base):
         DateTime(timezone=True),
         index=True,
     )
-    is_licensed: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_licensed: Mapped[bool] = mapped_column(Boolean, default=False, server_default=text("false"))
 
     # Timestamps
     first_seen: Mapped[datetime] = mapped_column(

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -4,7 +4,7 @@ import enum
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, Enum, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Enum, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -34,21 +34,21 @@ class Source(Base):
     # MeshMonitor specific
     url: Mapped[str | None] = mapped_column(String(500))
     api_token: Mapped[str | None] = mapped_column(String(500))
-    poll_interval_seconds: Mapped[int] = mapped_column(Integer, default=300)
+    poll_interval_seconds: Mapped[int] = mapped_column(Integer, default=300, server_default=text("300"))
     historical_days_back: Mapped[int] = mapped_column(
-        Integer, default=1
+        Integer, default=1, server_default=text("1")
     )  # Days of historical data to sync
 
     # MQTT specific
     mqtt_host: Mapped[str | None] = mapped_column(String(255))
-    mqtt_port: Mapped[int | None] = mapped_column(Integer, default=1883)
+    mqtt_port: Mapped[int | None] = mapped_column(Integer, default=1883, server_default=text("1883"))
     mqtt_username: Mapped[str | None] = mapped_column(String(255))
     mqtt_password: Mapped[str | None] = mapped_column(String(500))
     mqtt_topic_pattern: Mapped[str | None] = mapped_column(String(500))
-    mqtt_use_tls: Mapped[bool] = mapped_column(Boolean, default=False)
+    mqtt_use_tls: Mapped[bool] = mapped_column(Boolean, default=False, server_default=text("false"))
 
     # Common
-    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default=text("true"))
     last_poll_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_error: Mapped[str | None] = mapped_column(Text)
     remote_version: Mapped[str | None] = mapped_column(String(50))  # Version from remote source

--- a/backend/migrations/versions/set_missing_server_defaults.py
+++ b/backend/migrations/versions/set_missing_server_defaults.py
@@ -1,0 +1,88 @@
+"""Set missing server-side DEFAULT clauses on NOT NULL columns.
+
+Older installs bootstrapped via Base.metadata.create_all have columns with
+Python-side defaults but no PostgreSQL DEFAULT clause. Raw SQL INSERTs that
+omit these columns then fail with NOT NULL violations.
+
+This migration retroactively sets server defaults for all affected columns.
+All statements are idempotent (SET DEFAULT is a no-op if the default matches).
+
+Revision ID: p3q4r5s6t7u8
+Revises: o2p3q4r5s6t7
+Create Date: 2026-02-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "p3q4r5s6t7u8"
+down_revision: str = "o2p3q4r5s6t7"
+branch_labels = None
+depends_on = None
+
+# DEFAULT_PERMISSIONS JSON — colons escaped for SQLAlchemy text()
+_DEFAULT_PERMISSIONS_SQL = (
+    '\'{"map"\\: {"read"\\: true, "write"\\: false}, '
+    '"nodes"\\: {"read"\\: true, "write"\\: false}, '
+    '"graphs"\\: {"read"\\: true, "write"\\: false}, '
+    '"analysis"\\: {"read"\\: true, "write"\\: false}, '
+    '"communication"\\: {"read"\\: true, "write"\\: false}, '
+    '"settings"\\: {"read"\\: true, "write"\\: false}}\''
+)
+
+
+def upgrade() -> None:
+    # --- users ---
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN auth_provider SET DEFAULT 'local'"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN role SET DEFAULT 'user'"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN is_active SET DEFAULT TRUE"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN is_anonymous SET DEFAULT FALSE"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN totp_enabled SET DEFAULT FALSE"))
+    op.execute(
+        sa.text(f"ALTER TABLE users ALTER COLUMN permissions SET DEFAULT {_DEFAULT_PERMISSIONS_SQL}")
+    )
+
+    # --- nodes ---
+    op.execute(sa.text("ALTER TABLE nodes ALTER COLUMN is_licensed SET DEFAULT FALSE"))
+
+    # --- sources ---
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN poll_interval_seconds SET DEFAULT 300"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN historical_days_back SET DEFAULT 1"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN mqtt_port SET DEFAULT 1883"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN mqtt_use_tls SET DEFAULT FALSE"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN enabled SET DEFAULT TRUE"))
+
+    # --- channels ---
+    op.execute(sa.text("ALTER TABLE channels ALTER COLUMN uplink_enabled SET DEFAULT FALSE"))
+    op.execute(sa.text("ALTER TABLE channels ALTER COLUMN downlink_enabled SET DEFAULT FALSE"))
+
+    # --- messages ---
+    op.execute(sa.text("ALTER TABLE messages ALTER COLUMN channel SET DEFAULT 0"))
+
+
+def downgrade() -> None:
+    # --- users ---
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN auth_provider DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN role DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN is_active DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN is_anonymous DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN totp_enabled DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN permissions DROP DEFAULT"))
+
+    # --- nodes ---
+    op.execute(sa.text("ALTER TABLE nodes ALTER COLUMN is_licensed DROP DEFAULT"))
+
+    # --- sources ---
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN poll_interval_seconds DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN historical_days_back DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN mqtt_port DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN mqtt_use_tls DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE sources ALTER COLUMN enabled DROP DEFAULT"))
+
+    # --- channels ---
+    op.execute(sa.text("ALTER TABLE channels ALTER COLUMN uplink_enabled DROP DEFAULT"))
+    op.execute(sa.text("ALTER TABLE channels ALTER COLUMN downlink_enabled DROP DEFAULT"))
+
+    # --- messages ---
+    op.execute(sa.text("ALTER TABLE messages ALTER COLUMN channel DROP DEFAULT"))

--- a/backend/scripts/validate_server_defaults.py
+++ b/backend/scripts/validate_server_defaults.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""Validate that all NOT NULL columns with Python defaults also declare server_default.
+
+Introspects SQLAlchemy models via Base.metadata. For each NOT NULL column that
+has a Python-side ``default`` (not a FK, not a PK), checks that the model also
+declares ``server_default``. Exits non-zero if any are missing.
+
+Usage:
+    python scripts/validate_server_defaults.py
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure the backend package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import DateTime  # noqa: E402
+
+from app.database import Base  # noqa: E402
+
+# Import all models so they register with Base.metadata
+from app.models import (  # noqa: E402, F401
+    Channel,
+    Message,
+    Node,
+    Source,
+    User,
+)
+
+
+def validate() -> list[str]:
+    """Return a list of error messages for columns missing server_default."""
+    errors: list[str] = []
+
+    for table in Base.metadata.sorted_tables:
+        for column in table.columns:
+            # Skip primary keys — always explicitly provided
+            if column.primary_key:
+                continue
+
+            # Skip foreign keys — always explicitly provided
+            if column.foreign_keys:
+                continue
+
+            # Skip nullable columns — NULL is the implicit server default
+            if column.nullable:
+                continue
+
+            # Skip DateTime columns — timestamps use callable defaults (utc_now)
+            # and are always explicitly provided in both ORM and raw SQL
+            if isinstance(column.type, DateTime):
+                continue
+
+            # Only check columns that have a Python-side default
+            if column.default is None:
+                continue
+
+            # Column has a Python default but no server_default
+            if column.server_default is None:
+                errors.append(
+                    f"  {table.name}.{column.name}: "
+                    f"has default= but missing server_default="
+                )
+
+    return errors
+
+
+def main() -> None:
+    errors = validate()
+    if errors:
+        print("ERROR: The following columns have Python defaults but no server_default:")
+        print()
+        for err in errors:
+            print(err)
+        print()
+        print(
+            "Add server_default= to these mapped_column() calls and create "
+            "a migration with ALTER TABLE ... SET DEFAULT."
+        )
+        sys.exit(1)
+    else:
+        print("OK: All NOT NULL columns with Python defaults have server_default declarations.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_migration_integration.py
+++ b/backend/tests/test_migration_integration.py
@@ -1,0 +1,138 @@
+"""Integration tests for Alembic migrations.
+
+Verifies that the full migration chain can run against a fresh database
+and that running it twice is idempotent (no errors on re-run).
+
+Tests marked ``integration`` are skipped unless TEST_DATABASE_URL points
+at a PostgreSQL instance — the migrations use PostgreSQL-specific SQL.
+"""
+
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def _get_alembic_cfg() -> Config:
+    """Return an Alembic Config pointing at the backend directory."""
+    backend_dir = Path(__file__).resolve().parent.parent
+    cfg = Config(str(backend_dir / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_dir / "migrations"))
+    return cfg
+
+
+def test_set_missing_server_defaults_revision_exists():
+    """The set_missing_server_defaults migration exists and chains correctly."""
+    cfg = _get_alembic_cfg()
+    script_dir = ScriptDirectory.from_config(cfg)
+
+    rev = script_dir.get_revision("p3q4r5s6t7u8")
+    assert rev is not None, "Revision p3q4r5s6t7u8 not found"
+    assert rev.down_revision == "o2p3q4r5s6t7", (
+        f"Expected down_revision 'o2p3q4r5s6t7', got '{rev.down_revision}'"
+    )
+
+
+def test_set_missing_server_defaults_is_head():
+    """The set_missing_server_defaults migration should be the current head."""
+    cfg = _get_alembic_cfg()
+    script_dir = ScriptDirectory.from_config(cfg)
+
+    heads = script_dir.get_heads()
+    assert "p3q4r5s6t7u8" in heads, f"Expected p3q4r5s6t7u8 in heads, got {heads}"
+
+
+def test_model_server_defaults_present():
+    """All NOT NULL columns with Python defaults should declare server_default.
+
+    This duplicates what ``scripts/validate_server_defaults.py`` checks,
+    but runs as part of the standard pytest suite.
+    """
+    from sqlalchemy import DateTime
+
+    from app.database import Base
+
+    # Import all models to register them with Base.metadata
+    from app.models import (  # noqa: F401
+        Channel,
+        Message,
+        Node,
+        Source,
+        User,
+    )
+
+    missing: list[str] = []
+    for table in Base.metadata.sorted_tables:
+        for column in table.columns:
+            if column.primary_key or column.foreign_keys or column.nullable:
+                continue
+            if isinstance(column.type, DateTime):
+                continue
+            if column.default is None:
+                continue
+            if column.server_default is None:
+                missing.append(f"{table.name}.{column.name}")
+
+    assert not missing, (
+        f"Columns with Python default but no server_default: {', '.join(missing)}"
+    )
+
+
+@pytest.mark.integration
+def test_alembic_upgrade_head_fresh_db():
+    """Run alembic upgrade head on a fresh PostgreSQL database."""
+    import os
+
+    from alembic import command
+    from sqlalchemy import create_engine, text
+
+    db_url = os.environ.get("TEST_DATABASE_URL", "")
+    if not db_url:
+        pytest.skip("TEST_DATABASE_URL not set")
+
+    # Convert async URL to sync for alembic
+    sync_url = db_url.replace("+asyncpg", "").replace("+aiosqlite", "")
+
+    cfg = _get_alembic_cfg()
+    cfg.set_main_option("sqlalchemy.url", sync_url)
+
+    # Run upgrade head
+    command.upgrade(cfg, "head")
+
+    # Verify the anonymous user exists with correct defaults
+    engine = create_engine(sync_url)
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("SELECT id, is_anonymous, role, is_active FROM users WHERE username = 'anonymous'")
+        )
+        row = result.fetchone()
+        assert row is not None, "Anonymous user not found after upgrade"
+        assert row.is_anonymous is True
+        assert row.role == "user"
+        assert row.is_active is True
+
+    engine.dispose()
+
+
+@pytest.mark.integration
+def test_alembic_upgrade_head_idempotent():
+    """Running alembic upgrade head twice should not error (idempotency)."""
+    import os
+
+    from alembic import command
+
+    db_url = os.environ.get("TEST_DATABASE_URL", "")
+    if not db_url:
+        pytest.skip("TEST_DATABASE_URL not set")
+
+    sync_url = db_url.replace("+asyncpg", "").replace("+aiosqlite", "")
+
+    cfg = _get_alembic_cfg()
+    cfg.set_main_option("sqlalchemy.url", sync_url)
+
+    # First run
+    command.upgrade(cfg, "head")
+
+    # Second run — should be a no-op, not an error
+    command.upgrade(cfg, "head")


### PR DESCRIPTION
## Summary

- **Migration** (`set_missing_server_defaults`): Retroactively sets `ALTER TABLE ... SET DEFAULT` on 15 NOT NULL columns across `users`, `nodes`, `sources`, `channels`, and `messages` that had Python-side defaults but no PostgreSQL server default — fixing NOT NULL violations on raw SQL INSERTs from older installs bootstrapped via `create_all()`
- **Model updates**: Added `server_default=` to all affected `mapped_column()` calls so future `alembic revision --autogenerate` and `create_all()` in tests produce correct schemas
- **CI validation script** (`scripts/validate_server_defaults.py`): Introspects models to catch missing `server_default` declarations before they reach production — added as a step in the GitHub Actions backend workflow
- **Integration tests**: Verifies the new migration exists in the chain, is the current head, and that all models pass server_default validation

## Test plan

- [x] `pytest -x -q` — 289 passed, 32 skipped
- [x] `ruff check` — clean on all changed files
- [x] `python scripts/validate_server_defaults.py` — exits 0
- [x] `alembic heads` — single head `p3q4r5s6t7u8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)