### PR TITLE
feat: Support route_positions in traceroutes

### DIFF
--- a/backend/app/models/traceroute.py
+++ b/backend/app/models/traceroute.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import BigInteger, DateTime, ForeignKey, Index
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base, utc_now
@@ -47,6 +47,10 @@ class Traceroute(Base):
     # SNR data (arrays of floats as integers, dB * 4)
     snr_towards: Mapped[list[int] | None] = mapped_column(ARRAY(BigInteger))
     snr_back: Mapped[list[int] | None] = mapped_column(ARRAY(BigInteger))
+
+    # Historical positions of nodes at the time the traceroute was completed
+    # Keys are node number strings, values are {lat, lng, alt?}
+    route_positions: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     # Timestamp
     received_at: Mapped[datetime] = mapped_column(

--- a/backend/migrations/versions/add_route_positions_to_traceroutes.py
+++ b/backend/migrations/versions/add_route_positions_to_traceroutes.py
@@ -1,0 +1,37 @@
+"""Add route_positions JSONB column to traceroutes table.
+
+Stores historical node positions at the time a traceroute was completed,
+so the map draws routes to the correct (historical) locations even if
+nodes have moved since.
+
+Revision ID: q4r5s6t7u8v9
+Revises: p3q4r5s6t7u8
+Create Date: 2026-02-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "q4r5s6t7u8v9"
+down_revision: str = "p3q4r5s6t7u8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text("""
+            ALTER TABLE traceroutes
+            ADD COLUMN IF NOT EXISTS route_positions JSONB
+        """)
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("""
+            ALTER TABLE traceroutes
+            DROP COLUMN IF EXISTS route_positions
+        """)
+    )

--- a/backend/tests/test_migration_integration.py
+++ b/backend/tests/test_migration_integration.py
@@ -34,13 +34,13 @@ def test_set_missing_server_defaults_revision_exists():
     )
 
 
-def test_set_missing_server_defaults_is_head():
-    """The set_missing_server_defaults migration should be the current head."""
+def test_add_route_positions_is_head():
+    """The add_route_positions_to_traceroutes migration should be the current head."""
     cfg = _get_alembic_cfg()
     script_dir = ScriptDirectory.from_config(cfg)
 
     heads = script_dir.get_heads()
-    assert "p3q4r5s6t7u8" in heads, f"Expected p3q4r5s6t7u8 in heads, got {heads}"
+    assert "q4r5s6t7u8v9" in heads, f"Expected q4r5s6t7u8v9 in heads, got {heads}"
 
 
 def test_model_server_defaults_present():

--- a/backend/tests/test_mqtt_traceroute.py
+++ b/backend/tests/test_mqtt_traceroute.py
@@ -34,6 +34,11 @@ def mock_db():
     db = AsyncMock()
     db.add = MagicMock()
     db.commit = AsyncMock()
+    # Default execute returns a result with empty .all() for route position lookups
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_result.__iter__ = lambda self: iter([])
+    db.execute = AsyncMock(return_value=mock_result)
     return db
 
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -249,5 +249,6 @@ export interface Traceroute {
   to_node_num: number
   route: number[]
   route_back: number[] | null
+  route_positions: Record<string, { lat: number; lng: number; alt?: number }> | null
   received_at: string
 }


### PR DESCRIPTION
## Summary
- Adds `route_positions` JSONB column to traceroutes table, storing node coordinates at the time each traceroute was completed
- MeshMonitor collector parses the new `routePositions` API field; MQTT collector snapshots last-known node positions from the DB at ingestion time
- Frontend map rendering and connections endpoint prefer historical positions, falling back to current node positions when unavailable

## Changes

| File | Change |
|------|--------|
| `backend/app/models/traceroute.py` | Add `route_positions` JSONB column |
| `backend/migrations/versions/add_route_positions_to_traceroutes.py` | Idempotent migration to add column |
| `backend/app/collectors/meshmonitor.py` | Parse `routePositions` from MeshMonitor API |
| `backend/app/collectors/mqtt.py` | Build `route_positions` from last-known node positions |
| `backend/app/routers/ui.py` | Return `route_positions` in traceroutes API; use in connections endpoint |
| `frontend/src/types/api.ts` | Add field to `Traceroute` interface |
| `frontend/src/components/Map/MapContainer.tsx` | Prefer `route_positions` over live node positions |

## Test plan
- [x] Backend tests pass (289 passed)
- [x] Frontend tests pass (95 passed)
- [x] Linting clean
- [x] Dev deploy successful, migration ran cleanly
- [ ] Verify traceroutes from MeshMonitor sources with `routePositions` render at historical positions
- [ ] Verify traceroutes without `routePositions` (older MeshMonitor) still render using current node positions
- [ ] Verify MQTT traceroutes snapshot positions at ingestion and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)