### PR TITLE
fix: Drop stale message unique index and broaden duplicate handler

### DIFF
--- a/backend/app/collectors/mqtt.py
+++ b/backend/app/collectors/mqtt.py
@@ -183,7 +183,7 @@ class MqttCollector(BaseCollector):
                 await db.commit()
         except IntegrityError as e:
             err = str(e)
-            if "idx_messages_source_packet" in err or "idx_messages_source_packet_gateway" in err:
+            if "messages_source_packet" in err:
                 logger.debug("Duplicate message ignored (likely overlapping topics)")
             elif "idx_traceroutes_unique" in err:
                 logger.debug("Duplicate traceroute ignored")

--- a/backend/migrations/versions/drop_stale_message_source_packet_index.py
+++ b/backend/migrations/versions/drop_stale_message_source_packet_index.py
@@ -1,0 +1,41 @@
+"""Drop stale ix_messages_source_packet unique index.
+
+The gateway_node_num migration intended to drop this 2-column index and
+replace it with the 3-column idx_messages_source_packet_gateway index,
+but it referenced the wrong name (idx_ instead of ix_).  The stale
+index causes ON CONFLICT mismatches and noisy duplicate-key errors.
+
+Revision ID: r5s6t7u8v9w0
+Revises: q4r5s6t7u8v9
+Create Date: 2026-02-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "r5s6t7u8v9w0"
+down_revision: str = "q4r5s6t7u8v9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the stale 2-column unique index that was missed by the
+    # gateway_node_num migration (which tried to drop idx_ not ix_)
+    op.execute(
+        sa.text("DROP INDEX IF EXISTS ix_messages_source_packet")
+    )
+    # Also drop the wrong-name variant in case it exists on some databases
+    op.execute(
+        sa.text("DROP INDEX IF EXISTS idx_messages_source_packet")
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("""
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_messages_source_packet
+            ON messages (source_id, packet_id)
+        """)
+    )

--- a/backend/tests/test_migration_integration.py
+++ b/backend/tests/test_migration_integration.py
@@ -34,13 +34,13 @@ def test_set_missing_server_defaults_revision_exists():
     )
 
 
-def test_add_route_positions_is_head():
-    """The add_route_positions_to_traceroutes migration should be the current head."""
+def test_drop_stale_message_index_is_head():
+    """The drop_stale_message_source_packet_index migration should be the current head."""
     cfg = _get_alembic_cfg()
     script_dir = ScriptDirectory.from_config(cfg)
 
     heads = script_dir.get_heads()
-    assert "q4r5s6t7u8v9" in heads, f"Expected q4r5s6t7u8v9 in heads, got {heads}"
+    assert "r5s6t7u8v9w0" in heads, f"Expected r5s6t7u8v9w0 in heads, got {heads}"
 
 
 def test_model_server_defaults_present():


### PR DESCRIPTION
## Summary

- The `gateway_node_num` migration tried to drop `idx_messages_source_packet` but the actual index was named `ix_messages_source_packet` (SQLAlchemy auto-naming convention). The stale 2-column index was never removed.
- This caused the MQTT collector's duplicate message handler to miss the constraint name (`ix_` vs `idx_` prefix), logging "Unexpected integrity error" instead of silently ignoring duplicates
- Adds a migration to drop both `ix_` and `idx_` variants of the old 2-column index
- Broadens the MQTT collector's duplicate check to match any `*messages_source_packet*` constraint name

## Test plan

- [x] Backend tests pass (289 passed, 32 skipped)
- [x] Frontend tests pass (95 passed)
- [x] Verified on dev: stale index dropped, only `idx_messages_source_packet_gateway` remains
- [ ] Deploy to production and verify clean DB logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)