### PR TITLE
feat: Add propagation time metric and animated propagation map

### DIFF
--- a/frontend/src/components/Communication/MessageDetailModal.module.css
+++ b/frontend/src/components/Communication/MessageDetailModal.module.css
@@ -181,3 +181,36 @@
 .legend p:last-child {
   margin-bottom: 0;
 }
+
+.propagationRow {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.propagationTime {
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.propagationTime strong {
+  color: var(--color-text, #cdd6f4);
+}
+
+.propagationButton {
+  background: none;
+  border: 1px solid var(--color-primary, #89b4fa);
+  color: var(--color-primary, #89b4fa);
+  border-radius: 6px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.propagationButton:hover {
+  background: rgba(137, 180, 250, 0.12);
+  color: #b4d0fb;
+}

--- a/frontend/src/components/Communication/MessageList.tsx
+++ b/frontend/src/components/Communication/MessageList.tsx
@@ -378,9 +378,9 @@ export default function MessageList({ channelKey, onMessageClick, sourceNames }:
                           fontSize: '0.65rem',
                           fontWeight: 600,
                         }}
-                        title={`Received by ${msg.source_count} sources`}
+                        title={`Received ${msg.source_count} times (via different sources or gateways)`}
                       >
-                        {msg.source_count} sources
+                        {msg.source_count} copies
                       </span>
                     )}
                     <span

--- a/frontend/src/components/Communication/PropagationMapModal.module.css
+++ b/frontend/src/components/Communication/PropagationMapModal.module.css
@@ -1,0 +1,223 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.modal {
+  background: var(--color-surface, #1e1e2e);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 12px;
+  width: 92%;
+  max-width: 900px;
+  height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--color-border, #313244);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text, #cdd6f4);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--color-text-muted, #a6adc8);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.15s ease;
+}
+
+.closeButton:hover {
+  color: var(--color-text, #cdd6f4);
+}
+
+.mapContainer {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.mapContainer :global(.leaflet-container) {
+  height: 100%;
+  width: 100%;
+  border-radius: 0;
+  background: #1a1a2e;
+}
+
+.noDataMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-muted, #a6adc8);
+  font-size: 0.9rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.positionWarning {
+  padding: 0.5rem 1.25rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #a6adc8);
+  background: var(--color-surface-elevated, rgba(255, 255, 255, 0.03));
+  border-bottom: 1px solid var(--color-border, #313244);
+  flex-shrink: 0;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--color-border, #313244);
+  background: var(--color-surface-elevated, rgba(255, 255, 255, 0.03));
+  flex-shrink: 0;
+}
+
+.controlButton {
+  background: none;
+  border: 1px solid var(--color-border, #313244);
+  color: var(--color-text, #cdd6f4);
+  border-radius: 6px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.15s ease, border-color 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+}
+
+.controlButton:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--color-text-muted, #a6adc8);
+}
+
+.statusLabel {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #a6adc8);
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+.timeline {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  position: relative;
+  height: 20px;
+  min-width: 100px;
+}
+
+.timelineTrack {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--color-border, #313244);
+  border-radius: 2px;
+  transform: translateY(-50%);
+}
+
+.timelineFill {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 3px;
+  background: var(--color-primary, #89b4fa);
+  border-radius: 2px;
+  transform: translateY(-50%);
+  transition: width 0.3s ease;
+}
+
+.timelineDot {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-border, #313244);
+  border: 2px solid var(--color-surface, #1e1e2e);
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.15s ease;
+  z-index: 1;
+}
+
+.timelineDot:hover {
+  transform: translate(-50%, -50%) scale(1.3);
+}
+
+.timelineDotActive {
+  background: var(--color-primary, #89b4fa);
+}
+
+.timelineDotCurrent {
+  background: #a6e3a1;
+  transform: translate(-50%, -50%) scale(1.3);
+  box-shadow: 0 0 6px rgba(166, 227, 161, 0.5);
+}
+
+/* Gateway marker styles */
+.gatewayMarker {
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  transition: opacity 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.gatewayMarkerInactive {
+  background: #585b70;
+  opacity: 0.4;
+}
+
+.gatewayMarkerActive {
+  opacity: 1;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.gatewayMarkerPulsing {
+  opacity: 1;
+  border-color: rgba(255, 255, 255, 0.9);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(166, 227, 161, 0.6);
+  }
+  50% {
+    transform: scale(1.15);
+    box-shadow: 0 0 12px 4px rgba(166, 227, 161, 0.3);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(166, 227, 161, 0);
+  }
+}

--- a/frontend/src/components/Communication/PropagationMapModal.tsx
+++ b/frontend/src/components/Communication/PropagationMapModal.tsx
@@ -1,0 +1,386 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { MapContainer as LeafletMapContainer, TileLayer, Marker, Tooltip, useMap } from 'react-leaflet'
+import L from 'leaflet'
+import { useNodes } from '../../hooks/useNodes'
+import { getTilesetById, DEFAULT_TILESET_ID } from '../../config/tilesets'
+import type { MessageSourceDetail } from '../../services/api'
+import styles from './PropagationMapModal.module.css'
+
+interface PropagationMapModalProps {
+  sources: MessageSourceDetail[]
+  onClose: () => void
+}
+
+interface GatewayEvent {
+  gatewayNodeNum: number
+  name: string
+  lat: number
+  lng: number
+  timestamp: number
+  relativeTimeMs: number
+  order: number
+  sourceName: string
+  rxSnr: number | null
+}
+
+function getOrderColor(order: number, total: number): string {
+  if (total <= 1) return '#a6e3a1'
+  const ratio = order / (total - 1)
+  // green -> yellow -> red
+  if (ratio <= 0.5) {
+    const t = ratio * 2
+    const r = Math.round(166 + (249 - 166) * t)
+    const g = Math.round(227 + (226 - 227) * t)
+    const b = Math.round(161 + (175 - 161) * t)
+    return `rgb(${r},${g},${b})`
+  } else {
+    const t = (ratio - 0.5) * 2
+    const r = Math.round(249 + (243 - 249) * t)
+    const g = Math.round(226 + (139 - 226) * t)
+    const b = Math.round(175 + (168 - 175) * t)
+    return `rgb(${r},${g},${b})`
+  }
+}
+
+function createGatewayIcon(state: 'inactive' | 'active' | 'pulsing', color: string): L.DivIcon {
+  let className = styles.gatewayMarker
+  let style = ''
+
+  if (state === 'inactive') {
+    className += ' ' + styles.gatewayMarkerInactive
+  } else if (state === 'active') {
+    className += ' ' + styles.gatewayMarkerActive
+    style = `background: ${color};`
+  } else {
+    className += ' ' + styles.gatewayMarkerPulsing
+    style = `background: ${color}; box-shadow: 0 0 8px ${color};`
+  }
+
+  return L.divIcon({
+    className: '',
+    html: `<div class="${className}" style="width:18px;height:18px;${style}"></div>`,
+    iconSize: [22, 22],
+    iconAnchor: [11, 11],
+  })
+}
+
+function FitBoundsHandler({ positions }: { positions: [number, number][] }) {
+  const map = useMap()
+
+  useEffect(() => {
+    if (positions.length === 0) return
+    if (positions.length === 1) {
+      map.setView(positions[0], 12)
+      return
+    }
+    const bounds = L.latLngBounds(positions.map(p => L.latLng(p[0], p[1])))
+    map.fitBounds(bounds, { padding: [40, 40], maxZoom: 14 })
+  }, [map, positions])
+
+  return null
+}
+
+function formatRelativeTime(ms: number): string {
+  if (ms < 1000) return `+${ms}ms`
+  if (ms < 60000) return `+${(ms / 1000).toFixed(1)}s`
+  const mins = Math.floor(ms / 60000)
+  const secs = Math.round((ms % 60000) / 1000)
+  return `+${mins}m ${secs}s`
+}
+
+export default function PropagationMapModal({ sources, onClose }: PropagationMapModalProps) {
+  const { data: nodes } = useNodes()
+  const [currentStep, setCurrentStep] = useState(-1)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const gatewayEvents = useMemo<GatewayEvent[]>(() => {
+    if (!nodes || nodes.length === 0) return []
+
+    const nodeMap = new Map<number, { lat: number; lng: number; name: string }>()
+    for (const node of nodes) {
+      if (node.latitude !== null && node.longitude !== null) {
+        nodeMap.set(node.node_num, {
+          lat: node.latitude,
+          lng: node.longitude,
+          name: node.short_name || `!${node.node_num.toString(16).padStart(8, '0')}`,
+        })
+      }
+    }
+
+    // Group by gateway_node_num, keep earliest timestamp per gateway
+    const byGateway = new Map<number, { source: MessageSourceDetail; ts: number }>()
+    for (const s of sources) {
+      if (!s.gateway_node_num) continue
+      const nodeInfo = nodeMap.get(s.gateway_node_num)
+      if (!nodeInfo) continue
+
+      const tsStr = s.rx_time || s.received_at
+      const ts = new Date(tsStr).getTime()
+      if (isNaN(ts)) continue
+
+      const existing = byGateway.get(s.gateway_node_num)
+      if (!existing || ts < existing.ts) {
+        byGateway.set(s.gateway_node_num, { source: s, ts })
+      }
+    }
+
+    const sorted = Array.from(byGateway.entries())
+      .sort((a, b) => a[1].ts - b[1].ts)
+
+    if (sorted.length === 0) return []
+
+    const earliest = sorted[0][1].ts
+    return sorted.map(([nodeNum, { source, ts }], idx) => {
+      const nodeInfo = nodeMap.get(nodeNum)!
+      return {
+        gatewayNodeNum: nodeNum,
+        name: nodeInfo.name,
+        lat: nodeInfo.lat,
+        lng: nodeInfo.lng,
+        timestamp: ts,
+        relativeTimeMs: ts - earliest,
+        order: idx,
+        sourceName: source.source_name,
+        rxSnr: source.rx_snr,
+      }
+    })
+  }, [sources, nodes])
+
+  const totalGateways = new Set(sources.map(s => s.gateway_node_num).filter(Boolean)).size
+  const positionedCount = gatewayEvents.length
+
+  const positions = useMemo<[number, number][]>(
+    () => gatewayEvents.map(e => [e.lat, e.lng]),
+    [gatewayEvents]
+  )
+
+  // Animation engine
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isPlaying || gatewayEvents.length < 2) return
+
+    const nextStep = currentStep + 1
+    if (nextStep >= gatewayEvents.length) {
+      setIsPlaying(false)
+      return
+    }
+
+    // Compute delay proportional to real time deltas, scaled to ~4s total
+    const totalSpan = gatewayEvents[gatewayEvents.length - 1].relativeTimeMs
+    let delay: number
+    if (totalSpan === 0 || currentStep < 0) {
+      delay = 500
+    } else {
+      const delta = gatewayEvents[nextStep].relativeTimeMs - gatewayEvents[Math.max(0, currentStep)].relativeTimeMs
+      const scaleFactor = totalSpan > 0 ? 4000 / totalSpan : 1
+      delay = Math.min(2000, Math.max(300, delta * scaleFactor))
+    }
+
+    timerRef.current = setTimeout(() => {
+      setCurrentStep(nextStep)
+    }, delay)
+
+    return clearTimer
+  }, [isPlaying, currentStep, gatewayEvents, clearTimer])
+
+  useEffect(() => {
+    return clearTimer
+  }, [clearTimer])
+
+  const handlePlay = () => {
+    if (currentStep >= gatewayEvents.length - 1) {
+      setCurrentStep(-1)
+    }
+    setIsPlaying(true)
+    if (currentStep < 0) {
+      setCurrentStep(0)
+    }
+  }
+
+  const handlePause = () => {
+    setIsPlaying(false)
+    clearTimer()
+  }
+
+  const handleRestart = () => {
+    setIsPlaying(false)
+    clearTimer()
+    setCurrentStep(-1)
+  }
+
+  const handleStepForward = () => {
+    setIsPlaying(false)
+    clearTimer()
+    const next = currentStep + 1
+    if (next < gatewayEvents.length) {
+      setCurrentStep(next)
+    }
+  }
+
+  const handleJumpTo = (step: number) => {
+    setIsPlaying(false)
+    clearTimer()
+    setCurrentStep(step)
+  }
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  const tileset = getTilesetById(DEFAULT_TILESET_ID)
+
+  // Build status label
+  let statusText = ''
+  if (gatewayEvents.length > 0 && currentStep >= 0) {
+    const evt = gatewayEvents[currentStep]
+    const timeStr = evt.relativeTimeMs > 0 ? ` (${formatRelativeTime(evt.relativeTimeMs)})` : ''
+    statusText = `${currentStep + 1}/${gatewayEvents.length} — ${evt.name}${timeStr}`
+  } else if (gatewayEvents.length > 0) {
+    statusText = `0/${gatewayEvents.length} — Ready`
+  }
+
+  if (positionedCount === 0) {
+    return (
+      <div className={styles.overlay} onClick={handleOverlayClick}>
+        <div className={styles.modal} style={{ height: 'auto', maxHeight: '40vh' }}>
+          <div className={styles.header}>
+            <h3 className={styles.title}>Propagation Map</h3>
+            <button className={styles.closeButton} onClick={onClose} title="Close">&times;</button>
+          </div>
+          <div className={styles.noDataMessage}>
+            No gateways with known positions found.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.overlay} onClick={handleOverlayClick}>
+      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>Propagation Map</h3>
+          <button className={styles.closeButton} onClick={onClose} title="Close">&times;</button>
+        </div>
+
+        {positionedCount < totalGateways && (
+          <div className={styles.positionWarning}>
+            {positionedCount} of {totalGateways} gateways have known positions
+          </div>
+        )}
+
+        <div className={styles.mapContainer}>
+          <LeafletMapContainer
+            center={positions[0] || [0, 0]}
+            zoom={10}
+            style={{ height: '100%', width: '100%' }}
+          >
+            <TileLayer
+              attribution={tileset.attribution}
+              url={tileset.url}
+              maxZoom={tileset.maxZoom}
+            />
+            <FitBoundsHandler positions={positions} />
+
+            {gatewayEvents.map((evt) => {
+              let state: 'inactive' | 'active' | 'pulsing' = 'inactive'
+              if (currentStep >= 0) {
+                if (evt.order < currentStep) state = 'active'
+                else if (evt.order === currentStep) state = 'pulsing'
+              }
+
+              const color = getOrderColor(evt.order, gatewayEvents.length)
+              const icon = createGatewayIcon(state, color)
+
+              return (
+                <Marker
+                  key={evt.gatewayNodeNum}
+                  position={[evt.lat, evt.lng]}
+                  icon={icon}
+                >
+                  <Tooltip direction="top" offset={[0, -14]}>
+                    <strong>{evt.name}</strong><br />
+                    {evt.sourceName}
+                    {evt.rxSnr !== null && <><br />SNR: {evt.rxSnr.toFixed(1)} dB</>}
+                    {evt.relativeTimeMs > 0 && <><br />{formatRelativeTime(evt.relativeTimeMs)}</>}
+                  </Tooltip>
+                </Marker>
+              )
+            })}
+          </LeafletMapContainer>
+        </div>
+
+        {gatewayEvents.length >= 2 && (
+          <div className={styles.controls}>
+            <button
+              className={styles.controlButton}
+              onClick={isPlaying ? handlePause : handlePlay}
+              title={isPlaying ? 'Pause' : 'Play'}
+            >
+              {isPlaying ? '\u23F8' : '\u25B6'}
+            </button>
+            <button
+              className={styles.controlButton}
+              onClick={handleRestart}
+              title="Restart"
+            >
+              \u23EE
+            </button>
+            <button
+              className={styles.controlButton}
+              onClick={handleStepForward}
+              title="Step Forward"
+              disabled={currentStep >= gatewayEvents.length - 1}
+            >
+              \u23ED
+            </button>
+
+            <div className={styles.timeline}>
+              <div className={styles.timelineTrack} />
+              <div
+                className={styles.timelineFill}
+                style={{
+                  width: currentStep >= 0
+                    ? `${((currentStep + 1) / gatewayEvents.length) * 100}%`
+                    : '0%',
+                }}
+              />
+              {gatewayEvents.map((evt) => {
+                const totalSpan = gatewayEvents[gatewayEvents.length - 1].relativeTimeMs
+                const pct = totalSpan > 0
+                  ? (evt.relativeTimeMs / totalSpan) * 100
+                  : (evt.order / (gatewayEvents.length - 1)) * 100
+
+                let dotClass = styles.timelineDot
+                if (currentStep >= 0 && evt.order === currentStep) {
+                  dotClass += ' ' + styles.timelineDotCurrent
+                } else if (currentStep >= 0 && evt.order < currentStep) {
+                  dotClass += ' ' + styles.timelineDotActive
+                }
+
+                return (
+                  <div
+                    key={evt.gatewayNodeNum}
+                    className={dotClass}
+                    style={{ left: `${pct}%` }}
+                    onClick={() => handleJumpTo(evt.order)}
+                    title={`${evt.name}${evt.relativeTimeMs > 0 ? ' ' + formatRelativeTime(evt.relativeTimeMs) : ''}`}
+                  />
+                )
+              })}
+            </div>
+
+            <span className={styles.statusLabel}>{statusText}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Propagation Time**: Computes and displays the time delta between the earliest and latest reception of a message across sources/gateways (e.g. "850ms", "2.3s", "1m 12s") in the Message Detail Modal
- **Visualize Propagation**: New button (shown when 2+ copies exist) opens a map modal showing animated message propagation across gateways
- **Propagation Map Modal**: Dark-themed react-leaflet map with auto-fit bounds, color-coded gateway markers (green→yellow→red by reception order), pulse animation on current step, play/pause/restart/step controls, and a clickable timeline bar
- Renames "sources" badge to "copies" in the message list for clarity

### Edge cases handled
- Gateways without known positions: shows count warning
- Single positioned gateway: map with marker, no animation controls
- No positioned gateways: "No gateways with known positions found" message

## Test plan
- [x] `cd frontend && npm test -- --run` — all 95 tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Dev deploy builds and starts successfully
- [ ] Open a message with 2+ copies → verify propagation time shows
- [ ] Click "Visualize Propagation" → map opens, auto-fits bounds
- [ ] Play animation → markers light up chronologically with pulse effect
- [ ] Click timeline dots → jumps to correct step
- [ ] Close propagation map → returns to detail modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)