### PR TITLE
fix: Sort message reception sources by timestamp

### DIFF
--- a/frontend/src/components/Communication/MessageDetailModal.tsx
+++ b/frontend/src/components/Communication/MessageDetailModal.tsx
@@ -143,6 +143,11 @@ export default function MessageDetailModal({ packetId, onClose, senderName, mess
           )}
 
           {sources && sources.length > 0 && (() => {
+            const sortedSources = [...sources].sort((a, b) => {
+              const tsA = new Date(a.rx_time || a.received_at).getTime()
+              const tsB = new Date(b.rx_time || b.received_at).getTime()
+              return tsA - tsB
+            })
             const uniqueSources = new Set(sources.map(s => s.source_name)).size
             const uniqueGateways = new Set(sources.map(s => s.gateway_node_num).filter(Boolean)).size
             const total = sources.length
@@ -193,7 +198,7 @@ export default function MessageDetailModal({ packetId, onClose, senderName, mess
                   </tr>
                 </thead>
                 <tbody>
-                  {sources.map((source, index) => (
+                  {sortedSources.map((source, index) => (
                     <tr key={`${source.source_id}-${index}`}>
                       <td className={styles.sourceName}>{source.source_name}</td>
                       <td>


### PR DESCRIPTION
## Summary

- Sorts the sources table in the Message Detail Modal chronologically (earliest reception first) using `rx_time` with fallback to `received_at`
- Makes it easier to see the order in which gateways received the message

## Test plan
- [x] `cd frontend && npm test -- --run` — all 95 tests pass
- [x] Dev deploy builds and runs successfully
- [ ] Open a message with multiple copies → verify rows are ordered by time

🤖 Generated with [Claude Code](https://claude.com/claude-code)