### PR TITLE
chore: Bump version to 0.7.1

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.7.0"
+version = "0.7.1"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmanager-frontend",
-  "version": "0.6.6",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmanager-frontend",
-      "version": "0.6.6",
+      "version": "0.7.1",
       "dependencies": {
         "@catppuccin/palette": "^1.7.1",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bumps version to 0.7.1 in `backend/pyproject.toml`, `frontend/package.json`, and `frontend/package-lock.json`

## Test plan
- [x] Version strings updated in all locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)