### PR TITLE
feat: Add clock skew indicator to message detail modal

### DIFF
--- a/frontend/src/components/Communication/MessageDetailModal.module.css
+++ b/frontend/src/components/Communication/MessageDetailModal.module.css
@@ -214,3 +214,9 @@
   background: rgba(137, 180, 250, 0.12);
   color: #b4d0fb;
 }
+
+.clockSkew {
+  color: var(--color-warning, #f9e2af);
+  cursor: help;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary
- Adds a ⌚ icon next to source timestamps in the message detail modal when clock skew exceeds 30 seconds
- Compares the gateway radio's `rx_time` against the server's `received_at` to detect drift
- Hover tooltip shows the skew magnitude and direction (e.g., "+2m 15s")
- Legend entry explains the indicator

## Test plan
- [ ] Open a message detail modal with sources that have significant clock skew — ⌚ icon appears
- [ ] Hover the icon — tooltip shows skew details
- [ ] Sources with <30s skew show no icon
- [ ] Frontend tests pass (`cd frontend && npm test -- --run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)