### PR TITLE
chore: Bump version to 0.7.3

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.7.2"
+version = "0.7.3"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version from 0.7.2 → 0.7.3 in `backend/pyproject.toml` and `frontend/package.json`

### Changes since 0.7.2
- feat: Decode all known Meshtastic portnums and add PaxCounter handler (#112)
- fix: Use per-node charging/discharge hours in solar forecast simulation (#111)

## Test plan
- [x] Version strings updated in both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)