### PR TITLE
fix: Use lowercase enum values for PacketRecordType

### DIFF
--- a/backend/app/models/packet_record.py
+++ b/backend/app/models/packet_record.py
@@ -51,7 +51,9 @@ class PacketRecord(Base):
     meshtastic_id: Mapped[int | None] = mapped_column(BigInteger, index=True)
 
     packet_type: Mapped[PacketRecordType] = mapped_column(
-        Enum(PacketRecordType), nullable=False, index=True
+        Enum(PacketRecordType, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        index=True,
     )
     portnum: Mapped[str | None] = mapped_column(String(100), nullable=True)
 


### PR DESCRIPTION
## Summary
- SQLAlchemy's `Enum(PacketRecordType)` sends member **names** (ENCRYPTED, UNKNOWN, NODEINFO) by default, but the Alembic migration created the `packetrecordtype` PG enum with lowercase **values** (encrypted, unknown, nodeinfo)
- Add `values_callable` to the `Enum()` column definition so SQLAlchemy sends `.value` (lowercase) matching the database enum
- No migration needed — the PostgreSQL enum already has the correct lowercase values

**Error:** `invalid input value for enum packetrecordtype: "ENCRYPTED"`

## Test plan
- [x] `pytest -x -q` — 348 passed, 32 skipped
- [x] `ruff check` — clean
- [x] Verified `Enum(..., values_callable=...)` resolves to `['encrypted', 'unknown', 'nodeinfo']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)