### PR TITLE
fix: Handle fresh database bootstrap in entrypoint

### DIFF
--- a/backend/tests/test_init_db.py
+++ b/backend/tests/test_init_db.py
@@ -37,4 +37,22 @@ def test_entrypoint_contains_migration_commands():
     content = entrypoint.read_text()
     assert "alembic upgrade head" in content
     assert "alembic stamp d1e2f3g4h5i6" in content
+    assert "alembic stamp head" in content
     assert "alembic_version" in content
+
+
+def test_entrypoint_bootstrap_seeds_anonymous_user():
+    """Bootstrap path should seed the anonymous user."""
+    entrypoint = Path(__file__).parent.parent / "entrypoint.sh"
+    content = entrypoint.read_text()
+    assert "ANONYMOUS_USER_ID" in content
+    assert "anonymous" in content
+    assert "ON CONFLICT" in content
+
+
+def test_entrypoint_has_error_guards():
+    """entrypoint.sh should exit on detection or bootstrap failure."""
+    entrypoint = Path(__file__).parent.parent / "entrypoint.sh"
+    content = entrypoint.read_text()
+    assert "FATAL: Database state detection failed" in content
+    assert "FATAL: Schema creation failed" in content


### PR DESCRIPTION
## Summary
- Detects completely empty databases (no `alembic_version`, no `nodes` table) in `entrypoint.sh`
- Bootstraps the schema using `Base.metadata.create_all()` then stamps Alembic at `head`
- Seeds the anonymous user on bootstrap (since migration `upgrade()` functions are skipped when stamping)
- Adds error guards so detection/creation failures exit immediately instead of falling through
- Fixes startup failure when a user drops their database and restarts, since the root Alembic migration is a no-op

## Details

The entrypoint now detects three database states:
1. **`bootstrap`** — fresh empty DB: creates schema from current SQLAlchemy models, seeds required data, stamps Alembic at head
2. **`stamp`** — pre-migration DB (v0.5.2 or earlier): stamps at baseline revision, then upgrades (existing behavior)
3. **normal** — has `alembic_version`: runs `alembic upgrade head` (existing behavior)

### Review feedback addressed
- Anonymous user is now seeded after `create_all` + before `stamp head`
- Error guards (`|| exit 1`) added to detection script, schema creation, and seed step
- New tests verify bootstrap path seeds anonymous user and error guards exist

## Test plan
- [x] `pytest -x -q` — 350 passed, 32 skipped
- [x] `ruff check backend/` — no new lint issues
- [x] Frontend tests — 95 passed
- [x] Verified normal startup path (existing DB with `alembic_version`)
- [x] Verified bootstrap path: dropped all tables, restarted — schema created, anonymous user seeded, stamped at head, app fully running
- [x] Verified all 13 tables created correctly on fresh DB
- [x] Verified anonymous user row exists with correct UUID and permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)