### PR TITLE
fix: Truncate telemetry timestamps for Message Utilization dedup

### DIFF
--- a/backend/app/routers/ui.py
+++ b/backend/app/routers/ui.py
@@ -2070,10 +2070,13 @@ async def analyze_message_utilization(
             # Dedup: prefer meshtastic_id, fall back to timestamp-based key.
             # Use telemetry_type (not metric_name) because one packet produces
             # multiple metric rows — we want to count packets, not metrics.
+            # Truncate to second for the fallback key because MeshMonitor
+            # stores per-metric timestamps that differ by milliseconds
+            # within the same packet.
             if t.meshtastic_id is not None:
                 dedup_key = (t.node_num, t.meshtastic_id)
             else:
-                dedup_key = (t.node_num, t.telemetry_type, t.received_at)
+                dedup_key = (t.node_num, t.telemetry_type, t.received_at.replace(microsecond=0))
             if dedup_key in seen_telemetry:
                 continue
             seen_telemetry.add(dedup_key)


### PR DESCRIPTION
## Summary
- MeshMonitor stores one telemetry row per metric, each with a slightly different timestamp (millisecond differences). The Message Utilization analysis fallback dedup key (used when `meshtastic_id` is NULL) was using the exact `received_at`, so every metric row counted as a separate "packet" — inflating device telemetry counts by ~36x.
- Fix truncates `received_at` to the nearest second in the dedup key, collapsing metrics from the same packet while still distinguishing separate packets (which arrive minutes apart).

## Test plan
- [x] Backend test suite passes (350 passed)
- [x] Deployed to dev, verified Message Utilization numbers now align with MeshMonitor's 24-hour packet breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)