### PR TITLE
feat: Integrate MeshMonitor position-history API

### DIFF
--- a/backend/tests/test_meshmonitor_position_history.py
+++ b/backend/tests/test_meshmonitor_position_history.py
@@ -315,7 +315,8 @@ class TestCollectNodePositionHistory:
                 node_num=123,
             )
 
-        # count includes all items from data list, but only 1 was inserted
+        # count should reflect only actually inserted records (not skipped ones)
+        assert count == 1
         assert available is True
         # Only 1 execute call (the record with a timestamp)
         assert mock_db.execute.call_count == 1


### PR DESCRIPTION
## Summary
- Adds `_collect_node_position_history()` per-node fetcher that calls `GET /api/v1/nodes/{nodeId}/position-history` with offset pagination and `on_conflict_do_nothing` dedup
- Adds `_collect_position_history()` orchestrator that iterates all nodes from the local DB, with 404 early-exit for older MeshMonitor instances
- Integrates position history into `collect()`, `collect_since_last_poll()`, and `_collect_historical_background()` flows
- Closes the position undercount gap (293 vs 1800) caused by only capturing positions when they change between consecutive polls

## Test plan
- [x] 6 new tests in `test_meshmonitor_position_history.py` covering basic insert, pagination, 404 handling, null packetId, dedup, and missing-timestamp skip
- [x] Full backend test suite passes (356 passed, 32 skipped)
- [x] Frontend test suite passes (95 passed)
- [x] Lint clean (`ruff check` on changed files)
- [ ] Deploy to dev, trigger collection, verify POSITION telemetry rows appear
- [ ] Compare position counts against MeshMonitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)