### PR TITLE
fix: Exclude MeshMonitor metadata from Message Utilization packet counts

### DIFF
--- a/backend/app/routers/ui.py
+++ b/backend/app/routers/ui.py
@@ -24,7 +24,7 @@ from app.models.telemetry import TelemetryType
 from app.schemas.node import NodeResponse, NodeSummary
 from app.schemas.telemetry import TelemetryHistory, TelemetryHistoryPoint, TelemetryResponse
 from app.services.collector_manager import collector_manager
-from app.telemetry_registry import CAMEL_TO_METRIC, METRIC_REGISTRY
+from app.telemetry_registry import CAMEL_TO_METRIC, METRIC_REGISTRY, NON_MESH_METRICS
 
 router = APIRouter(prefix="/api", tags=["ui"])
 
@@ -2064,6 +2064,9 @@ async def analyze_message_utilization(
 
         seen_telemetry: set[tuple] = set()
         for t in telemetry_rows:
+            # Skip MeshMonitor metadata metrics (not actual mesh packets)
+            if t.metric_name in NON_MESH_METRICS:
+                continue
             # Skip telemetry from locally connected nodes if flag is set
             if exclude_local_nodes and (t.source_id, t.node_num) in local_nodes:
                 continue

--- a/backend/app/telemetry_registry.py
+++ b/backend/app/telemetry_registry.py
@@ -256,6 +256,37 @@ SUBMESSAGE_TYPE_MAP: dict[str, TelemetryType] = {
 
 
 # ---------------------------------------------------------------------------
+# Non-mesh metrics (MeshMonitor metadata, not actual Meshtastic packets)
+# ---------------------------------------------------------------------------
+
+NON_MESH_METRICS: frozenset[str] = frozenset({
+    # Position fields stored as DEVICE by MeshMonitor (already counted via POSITION telemetry)
+    "latitude",
+    "longitude",
+    "altitude",
+    "sats_in_view",
+    "ground_track",
+    "ground_speed",
+    # MeshMonitor neighbor/link metadata (not mesh packets)
+    "linkQuality",
+    "messageHops",
+    "snr_local",
+    "snr_remote",
+    "rssi",
+    # MeshMonitor estimated/internal
+    "estimated_latitude",
+    "estimated_longitude",
+    "timeOffset",
+    # MeshMonitor unknown flat-format metrics
+    "envCurrent",
+    "envVoltage",
+})
+"""Metric names that represent MeshMonitor metadata rather than actual Meshtastic
+mesh packets.  These are excluded from Message Utilization packet counts but
+still stored for graphs/dashboards."""
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `NON_MESH_METRICS` frozenset to `telemetry_registry.py` listing MeshMonitor metadata metric names (position fields, link quality, estimated coordinates, etc.) that aren't actual Meshtastic mesh packets
- Filters these metrics out in `analyze_message_utilization()` before dedup logic, so they no longer inflate packet counts
- Data is still stored and available for graphs/dashboards — only the utilization analysis counting is affected

## Test plan

- [x] Backend tests pass (356 passed)
- [x] Frontend tests pass (95 passed)
- [ ] Run Message Utilization analysis and verify nodes like N4CRE Charlie no longer show inflated device telemetry counts
- [ ] Verify nodes with real device telemetry (battery, voltage) still show correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)