### PR TITLE
chore: Bump version to 0.7.6

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshmanager"
-version = "0.7.5"
+version = "0.7.6"
 description = "Management and oversight application for MeshMonitor and Meshtastic MQTT"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmanager-frontend",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bumps version from 0.7.5 to 0.7.6 in both `backend/pyproject.toml` and `frontend/package.json`

## Test plan
- [ ] Verify version displays correctly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)