### PR TITLE
feat: Add data retention settings UI

### DIFF
--- a/frontend/src/components/Settings/RetentionSettings.tsx
+++ b/frontend/src/components/Settings/RetentionSettings.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getRetentionSettings, updateRetentionSettings, RetentionSettings as RetentionSettingsType } from '../../services/api'
+
+export default function RetentionSettings() {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState<RetentionSettingsType>({ messages: 30, telemetry: 7, traceroutes: 30 })
+  const [hasChanges, setHasChanges] = useState(false)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['retention-settings'],
+    queryFn: getRetentionSettings,
+  })
+
+  useEffect(() => {
+    if (data) {
+      setForm(data)
+      setHasChanges(false)
+    }
+  }, [data])
+
+  const mutation = useMutation({
+    mutationFn: updateRetentionSettings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['retention-settings'] })
+      setSuccessMsg('Retention settings saved successfully.')
+      setHasChanges(false)
+      setTimeout(() => setSuccessMsg(null), 3000)
+    },
+    onError: () => {
+      setErrorMsg('Failed to save retention settings.')
+      setTimeout(() => setErrorMsg(null), 5000)
+    },
+  })
+
+  const handleChange = (key: keyof RetentionSettingsType, value: string) => {
+    const num = parseInt(value, 10)
+    if (!isNaN(num) && num >= 1 && num <= 365) {
+      setForm((prev) => ({ ...prev, [key]: num }))
+      setHasChanges(true)
+      setSuccessMsg(null)
+      setErrorMsg(null)
+    }
+  }
+
+  const handleSave = () => {
+    mutation.mutate(form)
+  }
+
+  if (isLoading) return null
+
+  return (
+    <div className="settings-section">
+      <div className="settings-section-header">
+        <h2>Data Retention</h2>
+      </div>
+
+      <div className="settings-card">
+        <p className="settings-description">
+          Configure how long data is kept before automatic cleanup. The cleanup service runs every 24 hours.
+        </p>
+
+        <div className="form-group">
+          <label className="form-label">Messages</label>
+          <div className="custom-hours-input">
+            <input
+              type="number"
+              className="form-input"
+              min={1}
+              max={365}
+              value={form.messages}
+              onChange={(e) => handleChange('messages', e.target.value)}
+            />
+            <span className="hours-label">days</span>
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Telemetry</label>
+          <div className="custom-hours-input">
+            <input
+              type="number"
+              className="form-input"
+              min={1}
+              max={365}
+              value={form.telemetry}
+              onChange={(e) => handleChange('telemetry', e.target.value)}
+            />
+            <span className="hours-label">days</span>
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Traceroutes</label>
+          <div className="custom-hours-input">
+            <input
+              type="number"
+              className="form-input"
+              min={1}
+              max={365}
+              value={form.traceroutes}
+              onChange={(e) => handleChange('traceroutes', e.target.value)}
+            />
+            <span className="hours-label">days</span>
+          </div>
+        </div>
+
+        {successMsg && <p className="settings-hint" style={{ color: 'var(--ctp-green)' }}>{successMsg}</p>}
+        {errorMsg && <p className="settings-hint" style={{ color: 'var(--ctp-red)' }}>{errorMsg}</p>}
+
+        <button
+          className="btn btn-primary"
+          onClick={handleSave}
+          disabled={!hasChanges || mutation.isPending}
+        >
+          {mutation.isPending ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Settings/SettingsPage.tsx
+++ b/frontend/src/components/Settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useAuthContext } from '../../contexts/AuthContext'
 import ConfigExportImport from './ConfigExportImport'
+import RetentionSettings from './RetentionSettings'
 import DisplaySettings from './DisplaySettings'
 import SourcesSettings from './SourcesSettings'
 import UsersManagement from './UsersManagement'
@@ -54,6 +55,7 @@ export default function SettingsPage() {
         {activeTab === 'display' && (
           <>
             <DisplaySettings />
+            {canWriteSettings && <RetentionSettings />}
             {canWriteSettings && <ConfigExportImport />}
           </>
         )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -540,6 +540,23 @@ export async function testSolarNotification(): Promise<{ success: boolean; messa
   return response.data
 }
 
+// Retention Settings
+export interface RetentionSettings {
+  messages: number
+  telemetry: number
+  traceroutes: number
+}
+
+export async function getRetentionSettings(): Promise<RetentionSettings> {
+  const response = await api.get<RetentionSettings>('/api/settings/retention')
+  return response.data
+}
+
+export async function updateRetentionSettings(settings: RetentionSettings): Promise<RetentionSettings> {
+  const response = await api.put<RetentionSettings>('/api/settings/retention', settings)
+  return response.data
+}
+
 // Message Utilization Analysis
 export interface MessageUtilizationNode {
   node_num: number


### PR DESCRIPTION
## Summary
- Add GET/PUT `/api/settings/retention` endpoints to configure cleanup periods for messages, telemetry, and traceroutes (1-365 days)
- Add `RetentionSettings` component in Settings > Display tab with number inputs, save button, and success/error feedback
- Gated behind `canWriteSettings` permission so only admins see the card

## Test plan
- [ ] Backend tests pass (`pytest -x -q`)
- [ ] Frontend tests pass (`npm test -- --run`)
- [ ] Open Settings > Display tab as admin, confirm retention card appears with defaults (30/7/30)
- [ ] Change values, click Save, verify success message
- [ ] Refresh page, confirm values persist
- [ ] Verify non-admin users don't see the retention card
- [ ] Verify retention service picks up saved values for next cleanup cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)