### PR TITLE
fix: Add data type descriptions to retention settings

### DIFF
--- a/frontend/src/components/Settings/RetentionSettings.tsx
+++ b/frontend/src/components/Settings/RetentionSettings.tsx
@@ -64,6 +64,7 @@ export default function RetentionSettings() {
 
         <div className="form-group">
           <label className="form-label">Messages</label>
+          <p className="settings-hint">Text messages, replies, and reactions.</p>
           <div className="custom-hours-input">
             <input
               type="number"
@@ -79,6 +80,7 @@ export default function RetentionSettings() {
 
         <div className="form-group">
           <label className="form-label">Telemetry</label>
+          <p className="settings-hint">Device, environment, power, air quality, position, local stats, health, and host metrics.</p>
           <div className="custom-hours-input">
             <input
               type="number"
@@ -94,6 +96,7 @@ export default function RetentionSettings() {
 
         <div className="form-group">
           <label className="form-label">Traceroutes</label>
+          <p className="settings-hint">Route paths, SNR data, and node positions at time of trace.</p>
           <div className="custom-hours-input">
             <input
               type="number"


### PR DESCRIPTION
## Summary
- Add hint text below each retention input describing the data types affected
- Messages: text messages, replies, and reactions
- Telemetry: device, environment, power, air quality, position, local stats, health, and host metrics
- Traceroutes: route paths, SNR data, and node positions at time of trace

## Test plan
- [ ] Open Settings > Display tab, confirm hint text appears below each retention label
- [ ] Verify descriptions match actual data types in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)