### PR TITLE
feat: Add clickable edges to network connections graph

### DIFF
--- a/frontend/src/components/NodeDetails/EdgeDetailModal.module.css
+++ b/frontend/src/components/NodeDetails/EdgeDetailModal.module.css
@@ -1,0 +1,156 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: var(--color-surface, #1e1e2e);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 12px;
+  width: 90%;
+  max-width: 700px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border, #313244);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text, #cdd6f4);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--color-text-muted, #a6adc8);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.15s ease;
+}
+
+.closeButton:hover {
+  color: var(--color-text, #cdd6f4);
+}
+
+.summary {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border, #313244);
+  background: var(--color-surface-elevated, rgba(255, 255, 255, 0.03));
+}
+
+.connectionLabel {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-primary, #89b4fa);
+  margin-bottom: 0.5rem;
+}
+
+.statsRow {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.statsRow strong {
+  color: var(--color-text, #cdd6f4);
+}
+
+.content {
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.subtitle {
+  margin: 0 0 1rem 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.loading,
+.error,
+.empty {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.error {
+  color: var(--color-error, #f38ba8);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.table th {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 2px solid var(--color-border, #313244);
+  color: var(--color-text-muted, #a6adc8);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.table td {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--color-border, #313244);
+  color: var(--color-text, #cdd6f4);
+}
+
+.table tbody tr:hover {
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.03));
+}
+
+.numeric {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  text-align: right;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.legend {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: var(--color-surface-elevated, rgba(255, 255, 255, 0.03));
+  border-radius: 8px;
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #a6adc8);
+}
+
+.legend p {
+  margin: 0 0 0.5rem 0;
+}
+
+.legend p:last-child {
+  margin-bottom: 0;
+}

--- a/frontend/src/components/NodeDetails/EdgeDetailModal.tsx
+++ b/frontend/src/components/NodeDetails/EdgeDetailModal.tsx
@@ -1,0 +1,118 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchEdgeDetails } from '../../services/api'
+import styles from './EdgeDetailModal.module.css'
+
+interface EdgeDetailModalProps {
+  nodeA: number
+  nodeB: number
+  hours?: number
+  onClose: () => void
+}
+
+function formatDateTime(dateString: string): string {
+  const date = new Date(dateString)
+  return date.toLocaleString()
+}
+
+function formatSnr(snr: number | null): string {
+  if (snr === null) return '-'
+  return `${snr.toFixed(1)} dB`
+}
+
+export default function EdgeDetailModal({ nodeA, nodeB, hours = 24, onClose }: EdgeDetailModalProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['edge-details', nodeA, nodeB, hours],
+    queryFn: () => fetchEdgeDetails(nodeA, nodeB, hours),
+  })
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose()
+    }
+  }
+
+  return (
+    <div className={styles.overlay} onClick={handleOverlayClick}>
+      <div className={styles.modal}>
+        {/* Header */}
+        <div className={styles.header}>
+          <h3 className={styles.title}>Connection Details</h3>
+          <button className={styles.closeButton} onClick={onClose} title="Close">
+            &times;
+          </button>
+        </div>
+
+        {/* Connection summary */}
+        {data && (
+          <div className={styles.summary}>
+            <div className={styles.connectionLabel}>
+              {data.node_a.name} ↔ {data.node_b.name}
+            </div>
+            <div className={styles.statsRow}>
+              <span>Traversals: <strong>{data.usage_count}</strong></span>
+              {data.snr_stats && (
+                <>
+                  <span>SNR Min: <strong>{data.snr_stats.min_db} dB</strong></span>
+                  <span>SNR Avg: <strong>{data.snr_stats.avg_db} dB</strong></span>
+                  <span>SNR Max: <strong>{data.snr_stats.max_db} dB</strong></span>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className={styles.content}>
+          {isLoading && (
+            <div className={styles.loading}>Loading edge details...</div>
+          )}
+
+          {error && (
+            <div className={styles.error}>
+              Error loading details: {(error as Error).message}
+            </div>
+          )}
+
+          {data && data.recent_traversals.length === 0 && (
+            <div className={styles.empty}>No traversal data found for this connection.</div>
+          )}
+
+          {data && data.recent_traversals.length > 0 && (
+            <>
+              <p className={styles.subtitle}>
+                Recent traversals (showing {data.recent_traversals.length} of {data.usage_count}):
+              </p>
+
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Traceroute</th>
+                    <th>Direction</th>
+                    <th>SNR</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.recent_traversals.map((t, index) => (
+                    <tr key={index}>
+                      <td className={styles.timestamp}>{formatDateTime(t.received_at)}</td>
+                      <td>{t.from_node_name} → {t.to_node_name}</td>
+                      <td>{t.direction}</td>
+                      <td className={styles.numeric}>{formatSnr(t.snr_db)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              <div className={styles.legend}>
+                <p><strong>Traversals</strong>: Number of traceroutes that used this connection</p>
+                <p><strong>SNR</strong> (Signal-to-Noise Ratio): Higher is better. Good: &gt;0 dB, Excellent: &gt;10 dB</p>
+                <p><strong>Direction</strong>: &quot;towards&quot; = forward route, &quot;back&quot; = return route</p>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/NodeDetails/NodeConnections.module.css
+++ b/frontend/src/components/NodeDetails/NodeConnections.module.css
@@ -116,6 +116,47 @@
   color: var(--ctp-subtext1);
 }
 
+.legend {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 10;
+  background: var(--ctp-base);
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--ctp-surface2);
+  font-size: 0.8rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  pointer-events: auto;
+}
+
+.legendTitle {
+  font-weight: 600;
+  color: var(--ctp-text);
+  margin-bottom: 6px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 3px;
+  color: var(--ctp-subtext1);
+}
+
+.legendItem:last-child {
+  margin-bottom: 0;
+}
+
+.legendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .hoverTooltip {
   position: absolute;
   transform: translate(-50%, -100%);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -235,6 +235,48 @@ export async function fetchConnections(hours?: number, nodeNum?: number): Promis
   return response.data
 }
 
+// Edge Details
+export interface EdgeNodeInfo {
+  node_num: number
+  name: string
+  short_name: string | null
+}
+
+export interface EdgeSnrStats {
+  min_db: number
+  max_db: number
+  avg_db: number
+  sample_count: number
+}
+
+export interface EdgeTraversal {
+  from_node_num: number
+  to_node_num: number
+  from_node_name: string
+  to_node_name: string
+  direction: string
+  snr_db: number | null
+  received_at: string
+}
+
+export interface EdgeDetails {
+  node_a: EdgeNodeInfo
+  node_b: EdgeNodeInfo
+  usage_count: number
+  snr_stats: EdgeSnrStats | null
+  recent_traversals: EdgeTraversal[]
+}
+
+export async function fetchEdgeDetails(nodeA: number, nodeB: number, hours?: number): Promise<EdgeDetails> {
+  const params = new URLSearchParams()
+  params.append('node_a', nodeA.toString())
+  params.append('node_b', nodeB.toString())
+  if (hours) params.append('hours', hours.toString())
+
+  const response = await api.get<EdgeDetails>(`/api/connections/edge-details?${params.toString()}`)
+  return response.data
+}
+
 // Node Roles
 export async function fetchNodeRoles(): Promise<string[]> {
   const response = await api.get<string[]>('/api/nodes/roles')


### PR DESCRIPTION
## Summary
- Clicking an edge in the Network Connections force-directed graph now opens a detail modal showing the two connected nodes, total traversal count, SNR statistics (min/avg/max), and a table of recent traceroutes that used the link
- Added a color legend to the graph explaining node colors by connection count
- Implemented manual edge proximity detection to work around force-graph's shadow canvas painting nodes over links, which prevented most edges from being clickable

## Changes
| File | Description |
|------|-------------|
| `backend/app/routers/ui.py` | New `GET /api/connections/edge-details` endpoint |
| `frontend/src/services/api.ts` | `EdgeDetails` types + `fetchEdgeDetails()` function |
| `frontend/src/components/NodeDetails/EdgeDetailModal.tsx` | New modal component (follows `MessageDetailModal` pattern) |
| `frontend/src/components/NodeDetails/EdgeDetailModal.module.css` | Modal styles |
| `frontend/src/components/NodeDetails/NodeConnections.tsx` | Edge click handling, proximity detection, color legend |
| `frontend/src/components/NodeDetails/NodeConnections.module.css` | Legend styles |

## Test plan
- [x] Backend tests pass (356 passed)
- [x] Frontend tests pass (95 passed)
- [x] TypeScript compiles cleanly
- [x] ESLint clean on all changed files
- [x] Navigate to node details with network connections
- [ ] Hover edge — cursor changes to pointer
- [x] Click edge — modal appears with connection details, SNR stats, traversal table
- [x] Click overlay or × to close modal
- [x] Verify color legend displays in bottom-right corner
- [x] Verify origin node shows in lavender ("This Node")

🤖 Generated with [Claude Code](https://claude.com/claude-code)