### PR TITLE
fix: Filter unregistered metrics from available metrics endpoint

### DIFF
--- a/backend/app/routers/ui.py
+++ b/backend/app/routers/ui.py
@@ -265,7 +265,12 @@ async def get_available_metrics(
             if resolved:
                 metric_def = METRIC_REGISTRY.get(resolved)
 
-        canonical = metric_def.name if metric_def else metric_name
+        # Skip metrics not in the registry (e.g. position fields, link metadata)
+        # These have data in the DB but no history endpoint support
+        if not metric_def:
+            continue
+
+        canonical = metric_def.name
         type_key = telem_type.value if telem_type else "device"
 
         if canonical in consolidated:
@@ -273,8 +278,8 @@ async def get_available_metrics(
         else:
             consolidated[canonical] = {
                 "name": canonical,
-                "label": metric_def.label if metric_def else metric_name,
-                "unit": metric_def.unit if metric_def else "",
+                "label": metric_def.label,
+                "unit": metric_def.unit,
                 "type_key": type_key,
                 "count": count,
             }


### PR DESCRIPTION
## Summary
- The `/telemetry/{node_num}/metrics` endpoint was returning metrics (`latitude`, `longitude`, `altitude`, `linkQuality`, `messageHops`) that exist in the DB but aren't in `METRIC_REGISTRY`
- The frontend would request `/history/{metric}` for these, which rejects unknown metrics with 400
- Fix: skip metrics not found in the registry so the frontend only sees chartable metrics

## Test plan
- [x] Backend tests pass (356 passed)
- [ ] Load a node details page — no more 400 errors in logs for unregistered metrics
- [ ] Telemetry charts still display all valid metrics correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)