### PR TITLE
fix: Resolve gateway node from MeshMonitor /api/status endpoint

### DIFF
--- a/backend/app/collectors/meshmonitor.py
+++ b/backend/app/collectors/meshmonitor.py
@@ -160,7 +160,7 @@ class MeshMonitorCollector(BaseCollector):
                     data = response.json()
                     connection = data.get("connection", {})
                     local_node = connection.get("localNode")
-                    if local_node and local_node.get("nodeNum"):
+                    if local_node and local_node.get("nodeNum") is not None:
                         local_num = local_node["nodeNum"]
                         self._local_node_num = local_num
                         # Persist to the source row for API-level fallback
@@ -180,27 +180,20 @@ class MeshMonitorCollector(BaseCollector):
         except Exception as e:
             logger.warning(
                 f"Could not fetch /api/status for {self.source.name}: {e}, "
-                f"falling back to hops_away heuristic"
+                f"falling back to previously stored value"
             )
 
         # Fallback: use stored value from a previous successful fetch
         if self._local_node_num is not None:
             return
 
-        # Last resort: check the DB for a previously persisted value
-        try:
-            async with async_session_maker() as db:
-                result = await db.execute(
-                    select(Source.local_node_num).where(Source.id == self.source.id)
-                )
-                stored = result.scalar()
-                if stored is not None:
-                    self._local_node_num = stored
-                    logger.debug(
-                        f"Using stored local node for {self.source.name}: {stored}"
-                    )
-        except Exception as e:
-            logger.error(f"Could not resolve local node for {self.source.name}: {e}")
+        # Last resort: use the value already on the source object (loaded at startup)
+        if self.source.local_node_num is not None:
+            self._local_node_num = self.source.local_node_num
+            logger.debug(
+                f"Using stored local node for {self.source.name}: "
+                f"{self.source.local_node_num}"
+            )
 
     async def _api_get(
         self,

--- a/backend/app/collectors/meshmonitor.py
+++ b/backend/app/collectors/meshmonitor.py
@@ -142,20 +142,62 @@ class MeshMonitorCollector(BaseCollector):
         return headers
 
     async def _resolve_local_node(self) -> None:
-        """Look up the local node (hops_away=0) for this source and cache it."""
+        """Fetch the local node number from MeshMonitor's /api/status endpoint.
+
+        The /api/status endpoint returns the authoritative local node number
+        via connection.localNode.nodeNum.  We persist it on the Source row so
+        the API fallback (for old messages without gateway_node_num) can use
+        it without making an HTTP call.
+        """
+        # Try fetching from the MeshMonitor /api/status endpoint
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(
+                    f"{self.source.url}/api/status",
+                    headers=self._get_headers(),
+                )
+                if response.status_code == 200:
+                    data = response.json()
+                    connection = data.get("connection", {})
+                    local_node = connection.get("localNode")
+                    if local_node and local_node.get("nodeNum"):
+                        local_num = local_node["nodeNum"]
+                        self._local_node_num = local_num
+                        # Persist to the source row for API-level fallback
+                        async with async_session_maker() as db:
+                            result = await db.execute(
+                                select(Source).where(Source.id == self.source.id)
+                            )
+                            source = result.scalar()
+                            if source:
+                                source.local_node_num = local_num
+                                await db.commit()
+                        logger.debug(
+                            f"Resolved local node for {self.source.name} "
+                            f"from /api/status: {local_num}"
+                        )
+                        return
+        except Exception as e:
+            logger.warning(
+                f"Could not fetch /api/status for {self.source.name}: {e}, "
+                f"falling back to hops_away heuristic"
+            )
+
+        # Fallback: use stored value from a previous successful fetch
+        if self._local_node_num is not None:
+            return
+
+        # Last resort: check the DB for a previously persisted value
         try:
             async with async_session_maker() as db:
                 result = await db.execute(
-                    select(Node.node_num).where(
-                        Node.source_id == self.source.id,
-                        Node.hops_away == 0,
-                    ).order_by(Node.node_num).limit(1)
+                    select(Source.local_node_num).where(Source.id == self.source.id)
                 )
-                local_num = result.scalar()
-                if local_num is not None:
-                    self._local_node_num = local_num
+                stored = result.scalar()
+                if stored is not None:
+                    self._local_node_num = stored
                     logger.debug(
-                        f"Resolved local node for {self.source.name}: {local_num}"
+                        f"Using stored local node for {self.source.name}: {stored}"
                     )
         except Exception as e:
             logger.error(f"Could not resolve local node for {self.source.name}: {e}")

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -4,7 +4,7 @@ import enum
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, Enum, Integer, String, Text, text
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -52,6 +52,7 @@ class Source(Base):
     last_poll_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_error: Mapped[str | None] = mapped_column(Text)
     remote_version: Mapped[str | None] = mapped_column(String(50))  # Version from remote source
+    local_node_num: Mapped[int | None] = mapped_column(BigInteger)  # Local node number from MeshMonitor
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=utc_now,

--- a/backend/app/routers/messages.py
+++ b/backend/app/routers/messages.py
@@ -433,8 +433,8 @@ async def get_message_sources(
 
     # Pre-resolve MeshMonitor local nodes for gateway fallback.
     # MeshMonitor sources where gateway_node_num is NULL need the local node
-    # (hops_away=0) as their gateway. We batch-query upfront so the per-row
-    # loop can construct immutable response objects with the correct values.
+    # as their gateway. We use Source.local_node_num (fetched from MeshMonitor's
+    # /api/status endpoint) rather than guessing from hops_away=0.
     mm_source_ids = list({
         str(row.source_id) for row in rows
         if row.source_type == SourceType.MESHMONITOR and row.gateway_node_num is None
@@ -443,16 +443,18 @@ async def get_message_sources(
     if mm_source_ids:
         local_q = await db.execute(
             select(
-                Node.source_id,
-                Node.node_num,
+                Source.id.label("source_id"),
+                Source.local_node_num.label("node_num"),
                 func.coalesce(Node.long_name, Node.short_name).label("node_name"),
             )
-            .where(
-                Node.source_id.in_(mm_source_ids),
-                Node.hops_away == 0,
+            .outerjoin(
+                Node,
+                (Node.source_id == Source.id) & (Node.node_num == Source.local_node_num),
             )
-            .distinct(Node.source_id)
-            .order_by(Node.source_id)
+            .where(
+                Source.id.in_(mm_source_ids),
+                Source.local_node_num.isnot(None),
+            )
         )
         local_nodes = {str(r.source_id): r for r in local_q.all()}
 

--- a/backend/migrations/versions/add_local_node_num_to_sources.py
+++ b/backend/migrations/versions/add_local_node_num_to_sources.py
@@ -1,0 +1,34 @@
+"""Add local_node_num to sources table.
+
+Stores the authoritative local node number fetched from MeshMonitor's
+/api/status endpoint, replacing the unreliable hops_away=0 heuristic.
+
+Revision ID: c3d4e5f6g7h8
+Revises: b2c3d4e5f6g7
+Create Date: 2026-03-11
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6g7h8"
+down_revision: str = "b2c3d4e5f6g7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE sources
+        ADD COLUMN IF NOT EXISTS local_node_num BIGINT
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE sources
+        DROP COLUMN IF EXISTS local_node_num
+    """)

--- a/backend/tests/test_migration_integration.py
+++ b/backend/tests/test_migration_integration.py
@@ -34,13 +34,13 @@ def test_set_missing_server_defaults_revision_exists():
     )
 
 
-def test_add_meshtastic_id_columns_is_head():
-    """The add_meshtastic_id_columns migration should be the current head."""
+def test_add_local_node_num_to_sources_is_head():
+    """The add_local_node_num_to_sources migration should be the current head."""
     cfg = _get_alembic_cfg()
     script_dir = ScriptDirectory.from_config(cfg)
 
     heads = script_dir.get_heads()
-    assert "b2c3d4e5f6g7" in heads, f"Expected b2c3d4e5f6g7 in heads, got {heads}"
+    assert "c3d4e5f6g7h8" in heads, f"Expected c3d4e5f6g7h8 in heads, got {heads}"
 
 
 def test_model_server_defaults_present():

--- a/backend/tests/test_resolve_local_node.py
+++ b/backend/tests/test_resolve_local_node.py
@@ -1,0 +1,153 @@
+"""Tests for MeshMonitor _resolve_local_node — ensures correct gateway resolution."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.collectors.meshmonitor import MeshMonitorCollector
+from app.models import Source
+
+
+@pytest.fixture
+def meshmonitor_source():
+    """Create a mock MeshMonitor source."""
+    source = MagicMock(spec=Source)
+    source.id = "test-source-id"
+    source.name = "test-meshmonitor"
+    source.url = "http://localhost:8080"
+    source.api_token = "test-token"
+    source.local_node_num = None
+    return source
+
+
+@pytest.fixture
+def collector(meshmonitor_source):
+    """Create a MeshMonitorCollector instance."""
+    return MeshMonitorCollector(meshmonitor_source)
+
+
+def _mock_status_response(node_num, status_code=200):
+    """Create a mock httpx.Response for /api/status."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    if status_code == 200:
+        response.json.return_value = {
+            "status": "ok",
+            "connection": {
+                "connected": True,
+                "localNode": {
+                    "nodeNum": node_num,
+                    "nodeId": "!abcdef12",
+                    "longName": "Test Node",
+                    "shortName": "TST",
+                },
+            },
+        }
+    else:
+        response.json.return_value = {"error": "not found"}
+    return response
+
+
+class TestResolveLocalNode:
+    """Tests for _resolve_local_node gateway resolution."""
+
+    @patch("app.collectors.meshmonitor.async_session_maker")
+    async def test_successful_fetch_from_api_status(self, mock_session_maker, collector):
+        """Successful /api/status fetch sets _local_node_num and persists to DB."""
+        mock_source = MagicMock()
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = mock_source
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.commit = AsyncMock()
+
+        mock_session_maker.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=_mock_status_response(12345678))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await collector._resolve_local_node()
+
+        assert collector._local_node_num == 12345678
+        mock_source.local_node_num = 12345678  # Would have been set
+
+    @patch("app.collectors.meshmonitor.async_session_maker")
+    async def test_api_failure_falls_back_to_cached_value(self, mock_session_maker, collector):
+        """When /api/status fails and _local_node_num is already cached, keep it."""
+        collector._local_node_num = 99999999
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await collector._resolve_local_node()
+
+        assert collector._local_node_num == 99999999
+
+    async def test_api_failure_falls_back_to_stored_source_value(self, collector):
+        """When /api/status fails and no cache, use source.local_node_num."""
+        collector.source.local_node_num = 77777777
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await collector._resolve_local_node()
+
+        assert collector._local_node_num == 77777777
+
+    async def test_api_returns_no_local_node_falls_back(self, collector):
+        """When /api/status returns no localNode, fall back to stored value."""
+        collector.source.local_node_num = 55555555
+
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 200
+        response.json.return_value = {
+            "status": "ok",
+            "connection": {"connected": False, "localNode": None},
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await collector._resolve_local_node()
+
+        assert collector._local_node_num == 55555555
+
+    async def test_api_returns_500_falls_back(self, collector):
+        """When /api/status returns non-200, fall back to stored value."""
+        collector.source.local_node_num = 33333333
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=_mock_status_response(None, status_code=500))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await collector._resolve_local_node()
+
+        assert collector._local_node_num == 33333333
+
+    async def test_no_fallback_available_leaves_none(self, collector):
+        """When everything fails, _local_node_num stays None."""
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await collector._resolve_local_node()
+
+        assert collector._local_node_num is None


### PR DESCRIPTION
## Summary
- The `hops_away=0` heuristic for identifying the local gateway node was wrong — both the gateway AND direct neighbors have `hops_away=0`, causing incorrect/multiple gateways in the propagation view
- Now fetches the authoritative local node number from MeshMonitor's `/api/status` endpoint (`connection.localNode.nodeNum`)
- Persists the value in a new `local_node_num` column on the `sources` table so the API fallback for older messages uses the correct gateway
- Includes Alembic migration (idempotent with `IF NOT EXISTS`)

Closes #130

## Test plan
- [x] Backend tests pass (356 passed)
- [x] Frontend tests pass (95 passed)
- [x] Lint passes on changed files
- [ ] Dev deploy and verify gateway resolution shows the correct node (the WiFi-connected node, not a random neighbor)
- [ ] Check propagation view for messages — should show single correct gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)